### PR TITLE
fix(dashboard): keep API keys server-side

### DIFF
--- a/dashboard/CHAT_SETUP.md
+++ b/dashboard/CHAT_SETUP.md
@@ -35,7 +35,7 @@ OPENMEMORY_API_URL=http://localhost:8080
 # OPENMEMORY_API_KEY=your-secret-api-key
 ```
 
-This keeps backend API keys server-side. For local development only, you can set `NEXT_PUBLIC_API_URL` and `NEXT_PUBLIC_API_KEY` to make the browser call the backend directly, but `NEXT_PUBLIC_*` values are public in the browser bundle.
+This keeps backend API keys server-side. Set `NEXT_PUBLIC_API_URL` only when the dashboard must call a different URL directly; API keys should remain in the server-only `OPENMEMORY_API_KEY` or `OM_API_KEY` environment variables.
 
 ### 3. Start the Dashboard
 

--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -3,12 +3,6 @@ FROM node:20-alpine AS builder
 
 WORKDIR /app
 
-# Build-time public vars for Next.js client bundle
-ARG NEXT_PUBLIC_API_URL=http://localhost:8080
-ARG NEXT_PUBLIC_API_KEY=
-ENV NEXT_PUBLIC_API_URL=${NEXT_PUBLIC_API_URL}
-ENV NEXT_PUBLIC_API_KEY=${NEXT_PUBLIC_API_KEY}
-
 # Install dependencies
 COPY package*.json ./
 RUN npm install
@@ -23,11 +17,6 @@ RUN npm run build
 FROM node:20-alpine AS production
 
 WORKDIR /app
-
-ARG NEXT_PUBLIC_API_URL=http://localhost:8080
-ARG NEXT_PUBLIC_API_KEY=
-ENV NEXT_PUBLIC_API_URL=${NEXT_PUBLIC_API_URL}
-ENV NEXT_PUBLIC_API_KEY=${NEXT_PUBLIC_API_KEY}
 
 # Install only production dependencies
 COPY --from=builder /app/package.json ./package.json

--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -28,7 +28,7 @@ OPENMEMORY_API_URL=http://localhost:8080
 # OPENMEMORY_API_KEY=your-secret-api-key
 ```
 
-This keeps authenticated backend API keys on the server. For local development only, you can still use browser-direct configuration with `NEXT_PUBLIC_API_URL` and `NEXT_PUBLIC_API_KEY`, but `NEXT_PUBLIC_*` values are public in the browser bundle.
+This keeps authenticated backend API keys on the server. Set `NEXT_PUBLIC_API_URL` only when the dashboard must call a different URL directly; API keys should remain in the server-only `OPENMEMORY_API_KEY` or `OM_API_KEY` environment variables.
 
 ## Run the dashboard locally
 

--- a/dashboard/app/api/openmemory/[...path]/route.ts
+++ b/dashboard/app/api/openmemory/[...path]/route.ts
@@ -3,7 +3,7 @@ import { NextRequest } from 'next/server'
 export const runtime = 'nodejs'
 export const dynamic = 'force-dynamic'
 
-const BACKEND = (process.env.OPENMEMORY_API_URL || 'http://127.0.0.1:9432').replace(/\/+$/, '')
+const BACKEND = (process.env.OPENMEMORY_API_URL || 'http://127.0.0.1:8080').replace(/\/+$/, '')
 const API_KEY = process.env.OPENMEMORY_API_KEY || process.env.OM_API_KEY || ''
 
 async function proxy(req: NextRequest, ctx: { params: Promise<{ path?: string[] }> }) {

--- a/dashboard/lib/project-context.tsx
+++ b/dashboard/lib/project-context.tsx
@@ -39,7 +39,7 @@ export function ProjectProvider({ children }: { children: React.ReactNode }) {
     const fetchProjects = async () => {
         setIsLoading(true)
         try {
-            const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8080'
+            const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || '/api/openmemory'
             const res = await fetch(`${API_BASE_URL}/dashboard/projects`)
             if (res.ok) {
                 const data = await res.json()

--- a/dashboard/tests/auth-config.test.js
+++ b/dashboard/tests/auth-config.test.js
@@ -1,0 +1,17 @@
+const test = require('node:test')
+const assert = require('node:assert/strict')
+const fs = require('node:fs')
+
+const read = (path) => fs.readFileSync(path, 'utf8')
+
+test('dashboard proxy defaults to the backend port and compose keeps the API key server-side', () => {
+  const proxy = read('dashboard/app/api/openmemory/[...path]/route.ts')
+  const compose = read('docker-compose.yml')
+  const dockerfile = read('dashboard/Dockerfile')
+
+  assert.match(proxy, /process\.env\.OPENMEMORY_API_URL \|\| 'http:\/\/127\.0\.0\.1:8080'/)
+  assert.match(compose, /OPENMEMORY_API_URL=\$\{OPENMEMORY_API_URL:-http:\/\/openmemory:8080\}/)
+  assert.match(compose, /OPENMEMORY_API_KEY=\$\{OM_API_KEY:-\}/)
+  assert.doesNotMatch(compose, /NEXT_PUBLIC_API_KEY/)
+  assert.doesNotMatch(dockerfile, /NEXT_PUBLIC_API_KEY/)
+})

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -139,14 +139,11 @@ services:
     build:
       context: ./dashboard
       dockerfile: Dockerfile
-      args:
-        - NEXT_PUBLIC_API_URL=${NEXT_PUBLIC_API_URL:-http://localhost:8080}
-        - NEXT_PUBLIC_API_KEY=${NEXT_PUBLIC_API_KEY:-}
     ports:
       - '3000:3000'
     environment:
-      - NEXT_PUBLIC_API_URL=${NEXT_PUBLIC_API_URL:-http://localhost:8080}
-      - NEXT_PUBLIC_API_KEY=${NEXT_PUBLIC_API_KEY:-}
+      - OPENMEMORY_API_URL=${OPENMEMORY_API_URL:-http://openmemory:8080}
+      - OPENMEMORY_API_KEY=${OM_API_KEY:-}
     depends_on:
       openmemory:
         condition: service_healthy


### PR DESCRIPTION
## Description
Fixes #195.

The dashboard Docker deployment passed `NEXT_PUBLIC_API_KEY` into the browser bundle, while the server-side proxy was not configured by Compose and defaulted to the wrong backend port. This caused authenticated dashboard requests to return 401.

## Changes
- Default the dashboard proxy and project loader to the same-origin `/api/openmemory` path and backend port 8080.
- Pass `OM_API_KEY` only to the server-side `OPENMEMORY_API_KEY` environment variable.
- Remove `NEXT_PUBLIC_API_KEY` from Docker build/runtime wiring.
- Add a Node regression test for the proxy/Compose configuration.

## Compatibility
The existing `NEXT_PUBLIC_API_URL` override remains available for direct URL configurations. API keys now use server-only environment variables and are no longer exposed through the client bundle.

## Testing
- `node --test dashboard/tests/auth-config.test.js` — pass
- `docker compose config --quiet` — pass
- `npm run lint` — not run: dashboard dependencies could not be installed locally; `npm install` stalled with no output and was stopped.
- `npm run build` — not run for the same dependency-install limitation.

## Additional context
No Docker image build was run because it would require downloading the dashboard dependency tree; Compose configuration validation was completed successfully.