### PR TITLE
fix(dashboard): keep rewrite API credentials server-side

### DIFF
--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -3,12 +3,6 @@ FROM node:20-alpine AS builder
 
 WORKDIR /app
 
-# Build-time public vars for Next.js client bundle
-ARG NEXT_PUBLIC_API_URL=http://localhost:8080
-ARG NEXT_PUBLIC_API_KEY=
-ENV NEXT_PUBLIC_API_URL=${NEXT_PUBLIC_API_URL}
-ENV NEXT_PUBLIC_API_KEY=${NEXT_PUBLIC_API_KEY}
-
 # Install dependencies
 COPY package*.json ./
 RUN npm install
@@ -23,11 +17,6 @@ RUN npm run build
 FROM node:20-alpine AS production
 
 WORKDIR /app
-
-ARG NEXT_PUBLIC_API_URL=http://localhost:8080
-ARG NEXT_PUBLIC_API_KEY=
-ENV NEXT_PUBLIC_API_URL=${NEXT_PUBLIC_API_URL}
-ENV NEXT_PUBLIC_API_KEY=${NEXT_PUBLIC_API_KEY}
 
 # Install only production dependencies
 COPY --from=builder /app/package.json ./package.json

--- a/dashboard/lib/project-context.tsx
+++ b/dashboard/lib/project-context.tsx
@@ -39,7 +39,7 @@ export function ProjectProvider({ children }: { children: React.ReactNode }) {
     const fetchProjects = async () => {
         setIsLoading(true)
         try {
-            const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8080'
+            const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || '/api/openmemory'
             const res = await fetch(`${API_BASE_URL}/dashboard/projects`)
             if (res.ok) {
                 const data = await res.json()

--- a/dashboard/tests/auth-config.test.js
+++ b/dashboard/tests/auth-config.test.js
@@ -1,0 +1,18 @@
+const test = require('node:test')
+const assert = require('node:assert/strict')
+const fs = require('node:fs')
+const path = require('node:path')
+
+const root = path.resolve(__dirname, '..', '..')
+const read = (relativePath) => fs.readFileSync(path.resolve(root, relativePath), 'utf8')
+
+test('dashboard falls back to the server proxy without baking public API config', () => {
+  const context = read('dashboard/lib/project-context.tsx')
+  const proxy = read('dashboard/app/api/openmemory/[...path]/route.ts')
+  const dockerfile = read('dashboard/Dockerfile')
+
+  assert.match(context, /process\.env\.NEXT_PUBLIC_API_URL \|\| '\/api\/openmemory'/)
+  assert.match(proxy, /process\.env\.OPENMEMORY_API_URL \|\| 'http:\/\/127\.0\.0\.1:7331'/)
+  assert.doesNotMatch(dockerfile, /NEXT_PUBLIC_API_URL/)
+  assert.doesNotMatch(dockerfile, /NEXT_PUBLIC_API_KEY/)
+})


### PR DESCRIPTION
## Summary

- default dashboard project requests to the existing `/api/openmemory` server proxy
- stop baking API URLs and keys into the browser-facing Docker build environment
- add regression coverage for the proxy fallback and Docker configuration

This keeps `OPENMEMORY_API_KEY` on the server side while preserving an explicit `NEXT_PUBLIC_API_URL` override for deployments that intentionally use one.

## Validation

- `node --test dashboard/tests/auth-config.test.js`
- `cd dashboard && node --test tests/auth-config.test.js`
- `cd dashboard && npm run build`
- `git diff --check`