### PR TITLE
fix(dashboard): remove immutable memory controls

### DIFF
--- a/dashboard/CHAT_SETUP.md
+++ b/dashboard/CHAT_SETUP.md
@@ -6,9 +6,8 @@ The chat interface is now connected to the OpenMemory backend and can query memo
 
 ✅ **Memory Querying**: Searches your memory database for relevant content
 ✅ **Salience-based Results**: Shows top memories ranked by relevance
-✅ **Memory Reinforcement**: Click the + button to boost memory importance
+✅ **Read-only Memory References**: Shows the memories used to generate each response
 ✅ **Real-time Updates**: Live connection to backend API
-✅ **Action Buttons**: Quick actions after assistant responses
 
 ## Setup Instructions
 
@@ -99,19 +98,17 @@ curl -X POST http://localhost:8080/memory/ingest \
 4. **Results**: Top 5 memories returned with salience scores
 5. **Response**: Chat generates answer based on retrieved memories
 
-### Memory Reinforcement
+### Memory References
 
-Clicking the **+** button on a memory card:
-
-- Sends POST to `/memory/reinforce`
-- Increases memory salience by 0.1
-- Makes it more likely to appear in future queries
+Memory cards shown beside a chat response are read-only references. Their salience is
+updated by the backend from observed evidence, so the dashboard does not expose
+manual reinforcement controls.
 
 ## Current Features
 
 ✅ Real-time memory querying
 ✅ Salience-based ranking
-✅ Memory reinforcement (boost)
+✅ Read-only memory references
 ✅ Sector classification display
 ✅ Error handling with backend status
 
@@ -149,7 +146,6 @@ Clicking the **+** button on a memory card:
 ```typescript
 POST /memory/query      // Search memories
 POST /memory/add        // Add new memory
-POST /memory/reinforce  // Boost memory salience
 GET  /memory/all        // List all memories
 GET  /memory/:id        // Get specific memory
 ```

--- a/dashboard/app/chat/page.tsx
+++ b/dashboard/app/chat/page.tsx
@@ -118,22 +118,6 @@ export default function ChatPage() {
         }
     }
 
-    const addMemoryToBag = async (memory: MemoryReference) => {
-        try {
-            await fetch(`${API_BASE_URL}/memory/reinforce`, {
-                method: "POST",
-                headers: getHeaders(),
-                body: JSON.stringify({
-                    id: memory.id,
-                    boost: 0.1
-                })
-            })
-            console.log("Memory reinforced:", memory.id)
-        } catch (error) {
-            console.error("Error reinforcing memory:", error)
-        }
-    }
-
     return (
         <div className="flex flex-col min-h-screen w-full" suppressHydrationWarning>
             <div className="grid grid-cols-1 lg:grid-cols-[1fr_320px] gap-8 mt-6 mb-16" suppressHydrationWarning>
@@ -253,16 +237,6 @@ export default function ChatPage() {
                                                         {memory.content}
                                                     </p>
                                                 </div>
-                                                <button
-                                                    onClick={() => addMemoryToBag(memory)}
-                                                    className="shrink-0 h-9 w-9 inline-flex items-center justify-center rounded-xl bg-stone-900/70 border border-zinc-800 text-stone-400 hover:text-white hover:bg-stone-800 transition-colors"
-                                                    aria-label="Add to bag"
-                                                    title="Add to bag"
-                                                >
-                                                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" className="h-4 w-4">
-                                                        <path strokeLinecap="round" strokeLinejoin="round" d="M12 5v14M19 12H5" />
-                                                    </svg>
-                                                </button>
                                             </div>
                                         </div>
                                     </div>

--- a/dashboard/app/decay/page.tsx
+++ b/dashboard/app/decay/page.tsx
@@ -101,20 +101,6 @@ export default function decay() {
         }
     }
 
-    async function boostmemory(id: string) {
-        try {
-            const res = await fetch(`${API_BASE_URL}/memory/${id}`, {
-                method: 'PATCH',
-                headers: getHeaders(),
-                body: JSON.stringify({ salience: 0.8 })
-            })
-            if (!res.ok) throw new Error('failed to boost memory')
-            fetchdata()
-        } catch (e: any) {
-            alert(`Error: ${e.message}`)
-        }
-    }
-
     useEffect(() => {
         if (!chartref.current || stats.length === 0) return
 
@@ -333,6 +319,9 @@ export default function decay() {
                             </svg>
                             Memories At Risk
                         </legend>
+                        <p className="mb-4 text-sm text-stone-500">
+                            Salience is updated from observed evidence; this view is for monitoring only.
+                        </p>
                         <div className="space-y-3" suppressHydrationWarning>
                             {riskmems.length === 0 ? (
                                 <div className="text-center py-8 text-stone-500" suppressHydrationWarning>
@@ -341,7 +330,7 @@ export default function decay() {
                             ) : (
                                 riskmems.map(mem => (
                                     <div key={mem.id} className="rounded-xl border border-rose-500/15 bg-rose-500/10 p-4 hover:bg-rose-500/15 transition-colors" suppressHydrationWarning>
-                                        <div className="flex items-center justify-between gap-4" suppressHydrationWarning>
+                                        <div className="flex items-center gap-4" suppressHydrationWarning>
                                             <div className="flex-1" suppressHydrationWarning>
                                                 <div className="flex items-center gap-2 mb-2" suppressHydrationWarning>
                                                     <span className="text-xs px-2 py-1 rounded-lg bg-stone-900 text-stone-300 uppercase tracking-wide">
@@ -351,15 +340,6 @@ export default function decay() {
                                                 </div>
                                                 <p className="text-sm text-stone-300">{mem.content}</p>
                                             </div>
-                                            <button
-                                                onClick={() => boostmemory(mem.id)}
-                                                className="rounded-xl p-2 pl-4 bg-blue-600 hover:bg-blue-700 transition-colors flex items-center gap-2 text-white font-medium"
-                                            >
-                                                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth="1.5" stroke="currentColor" className="size-5">
-                                                    <path strokeLinecap="round" strokeLinejoin="round" d="M3 13.125C3 12.504 3.504 12 4.125 12h2.25c.621 0 1.125.504 1.125 1.125v6.75C7.5 20.496 6.996 21 6.375 21h-2.25A1.125 1.125 0 0 1 3 19.875v-6.75ZM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V8.625ZM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V4.125Z" />
-                                                </svg>
-                                                Boost
-                                            </button>
                                         </div>
                                     </div>
                                 ))
@@ -371,5 +351,3 @@ export default function decay() {
         </div>
     )
 }
-
-

--- a/dashboard/tests/mutation-controls.test.js
+++ b/dashboard/tests/mutation-controls.test.js
@@ -1,0 +1,24 @@
+const assert = require("node:assert/strict")
+const fs = require("node:fs")
+const path = require("node:path")
+const test = require("node:test")
+
+const readDashboardFile = (relativePath) =>
+    fs.readFileSync(path.join(__dirname, "..", relativePath), "utf8")
+
+test("dashboard pages do not offer immutable memory mutations", () => {
+    const decayPage = readDashboardFile("app/decay/page.tsx")
+    const chatPage = readDashboardFile("app/chat/page.tsx")
+
+    assert.doesNotMatch(decayPage, /memory\/\$\{id\}/)
+    assert.doesNotMatch(decayPage, /method:\s*["']PATCH["']/)
+    assert.doesNotMatch(decayPage, /boostmemory|>\s*Boost\s*</)
+    assert.doesNotMatch(chatPage, /memory\/reinforce|addMemoryToBag|Add to bag/)
+})
+
+test("chat setup documents memory references as read-only", () => {
+    const setup = readDashboardFile("CHAT_SETUP.md")
+
+    assert.match(setup, /Read-only Memory References/)
+    assert.doesNotMatch(setup, /memory\/reinforce|Memory Reinforcement|boost memory importance/i)
+})


### PR DESCRIPTION
## Summary

- remove the Decay page Boost action because rewrite memories reject PATCH mutations
- remove Chat memory reinforcement controls because the compatibility proxy returns an immutable-memory conflict
- describe cited memories as read-only, evidence-driven references in the chat setup guide
- add regression coverage so unsupported mutation controls are not reintroduced

The ingest and query flows remain available; this only removes controls that cannot succeed against the rewrite API.

## Validation

- `node --test dashboard/tests/mutation-controls.test.js` (2 passed)
- `cd dashboard && node --test tests/mutation-controls.test.js` (2 passed)
- `cd dashboard && npm run build`
- `git diff --check`

`npm run lint` is not available in this branch because ESLint is not declared or installed.