### PR TITLE
feat: add OrcaRouter as a named embedding provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -62,7 +62,7 @@ OM_WEAVIATE_CLASS=OpenMemory
 # --------------------------------------------
 # Embeddings Configuration
 # --------------------------------------------
-# Available providers: openai, gemini, aws, ollama, local, synthetic
+# Available providers: openai, gemini, aws, ollama, local, synthetic, orcarouter
 # Embedding models per sector can be configured in models.yaml
 #
 # NOTE: Your selected TIER (fast/smart/deep) affects how embeddings work:
@@ -99,6 +99,11 @@ OM_EMBED_DELAY_MS=200
 # Model override for all sector embeddings (leave empty to use defaults)
 # OM_OPENAI_MODEL=text-embedding-qwen3-embedding-4b
 
+# OrcaRouter Embeddings (OpenAI-compatible gateway)
+# OM_ORCAROUTER_BASE_URL=https://api.orcarouter.ai/v1
+# Model override for all sector embeddings (leave empty to use defaults)
+# OM_ORCAROUTER_EMBEDDING_MODEL=orcarouter/auto
+
 # API Configuration
 # Max request body size in bytes (default: 1MB)
 OM_MAX_PAYLOAD_SIZE=1000000
@@ -119,6 +124,9 @@ AWS_REGION=us-east-1
 
 # Ollama Local Embeddings
 OLLAMA_URL=http://localhost:11434
+
+# OrcaRouter (OpenAI-compatible gateway; keys start with sk-orca-)
+ORCAROUTER_API_KEY=sk-orca-your-key-here
 
 # Local Model Path (for custom embedding models)
 LOCAL_MODEL_PATH=/path/to/your/local/model

--- a/README.md
+++ b/README.md
@@ -308,7 +308,7 @@ results = mem.search("allergies", user_id="user123")
   “Waypoint” traces that show exactly which nodes were used in context.
 
 - **Embeddings**  
-  OpenAI, Gemini, Ollama, AWS, synthetic fallback.
+  OpenAI, Gemini, Ollama, AWS, [OrcaRouter](https://www.orcarouter.ai), synthetic fallback.
 
 - **Integrations**  
   LangChain, CrewAI, AutoGen, Streamlit, MCP, VS Code, IDEs.

--- a/dashboard/app/api/settings/route.ts
+++ b/dashboard/app/api/settings/route.ts
@@ -50,6 +50,7 @@ export async function GET() {
         if (masked.GEMINI_API_KEY) masked.GEMINI_API_KEY = '***'
         if (masked.AWS_SECRET_ACCESS_KEY) masked.AWS_SECRET_ACCESS_KEY = "***"
         if (masked.OM_API_KEY) masked.OM_API_KEY = '***'
+        if (masked.ORCAROUTER_API_KEY) masked.ORCAROUTER_API_KEY = '***'
 
         return NextResponse.json({
             exists: true,

--- a/dashboard/app/settings/page.tsx
+++ b/dashboard/app/settings/page.tsx
@@ -168,7 +168,7 @@ const SETTING_METADATA: Record<string, SettingInfo> = {
         label: 'Embedding Provider',
         description: 'AI provider for generating embeddings (used in SMART/DEEP tiers)',
         type: 'select',
-        options: ['openai', 'gemini', 'aws', 'ollama', 'local', 'synthetic']
+        options: ['openai', 'gemini', 'aws', 'ollama', 'local', 'synthetic', 'orcarouter']
     },
     OM_VEC_DIM: {
         category: 'Embeddings',
@@ -211,6 +211,20 @@ const SETTING_METADATA: Record<string, SettingInfo> = {
         type: 'text',
         placeholder: 'text-embedding-3-small'
     },
+    OM_ORCAROUTER_BASE_URL: {
+        category: 'Embeddings',
+        label: 'OrcaRouter Base URL',
+        description: 'OrcaRouter OpenAI-compatible API endpoint',
+        type: 'text',
+        placeholder: 'https://api.orcarouter.ai/v1'
+    },
+    OM_ORCAROUTER_EMBEDDING_MODEL: {
+        category: 'Embeddings',
+        label: 'OrcaRouter Model Override',
+        description: 'Override default embedding model for all sectors',
+        type: 'text',
+        placeholder: 'orcarouter/auto'
+    },
     OM_MAX_PAYLOAD_SIZE: {
         category: 'Embeddings',
         label: 'Max Payload Size (bytes)',
@@ -224,6 +238,13 @@ const SETTING_METADATA: Record<string, SettingInfo> = {
         description: 'API key for OpenAI embeddings',
         type: 'password',
         placeholder: 'sk-...'
+    },
+    ORCAROUTER_API_KEY: {
+        category: 'API Keys',
+        label: 'OrcaRouter API Key',
+        description: 'API key for OrcaRouter embeddings (sk-orca-...)',
+        type: 'password',
+        placeholder: 'sk-orca-...'
     },
     GEMINI_API_KEY: {
         category: 'API Keys',

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -38,7 +38,7 @@ Configure your MCP client (`.mcp.json` for Cursor/Windsurf, or Claude settings):
 #### Environment Variables
 
 - `OM_METADATA_BACKEND`: Database type (`sqlite` or `postgres`)
-- `OM_EMBEDDINGS`: Embedding provider (`openai`, `aws`, `ollama`, `synthetic`)
+- `OM_EMBEDDINGS`: Embedding provider (`openai`, `aws`, `ollama`, `synthetic`, `orcarouter`)
 - Database credentials (if using Postgres): `OM_PG_HOST`, `OM_PG_DB`, `OM_PG_USER`, `OM_PG_PASSWORD`
 
 ## Memory Systems
@@ -612,7 +612,7 @@ If `type="factual"` returns no results:
 
 Ensure environment variables are set:
 - Postgres: `OM_PG_HOST`, `OM_PG_DB`, `OM_PG_USER`, `OM_PG_PASSWORD`
-- Embeddings: `OPENAI_API_KEY` (or relevant provider key)
+- Embeddings: `OPENAI_API_KEY` (or relevant provider key, e.g. `ORCAROUTER_API_KEY`)
 
 ## Performance
 

--- a/models.yml
+++ b/models.yml
@@ -11,6 +11,7 @@ episodic:
   gemini: models/gemini-embedding-001
   aws: amazon.titan-embed-text-v2:0
   local: all-MiniLM-L6-v2
+  orcarouter: orcarouter/auto
 
 semantic:
   ollama: nomic-embed-text
@@ -18,6 +19,7 @@ semantic:
   gemini: models/gemini-embedding-001
   aws: amazon.titan-embed-text-v2:0
   local: all-MiniLM-L6-v2
+  orcarouter: orcarouter/auto
 
 procedural:
   ollama: nomic-embed-text
@@ -25,6 +27,7 @@ procedural:
   gemini: models/gemini-embedding-001
   aws: amazon.titan-embed-text-v2:0
   local: all-MiniLM-L6-v2
+  orcarouter: orcarouter/auto
 
 emotional:
   ollama: nomic-embed-text
@@ -32,6 +35,7 @@ emotional:
   gemini: models/gemini-embedding-001
   aws: amazon.titan-embed-text-v2:0
   local: all-MiniLM-L6-v2
+  orcarouter: orcarouter/auto
 
 reflective:
   ollama: nomic-embed-text
@@ -39,6 +43,7 @@ reflective:
   gemini: models/gemini-embedding-001
   aws: amazon.titan-embed-text-v2:0
   local: all-mpnet-base-v2
+  orcarouter: orcarouter/auto
 # Available Ollama models (pull with: ollama pull <model>)
 # - nomic-embed-text (768d, recommended)
 # - mxbai-embed-large (1024d)

--- a/packages/openmemory-js/src/core/cfg.ts
+++ b/packages/openmemory-js/src/core/cfg.ts
@@ -63,6 +63,14 @@ export const env = {
         process.env.OM_SIRAY_BASE_URL,
         "https://api.siray.ai/v1",
     ),
+    orcarouter_key:
+        process.env.ORCAROUTER_API_KEY || process.env.OM_ORCAROUTER_API_KEY || "",
+    orcarouter_base_url: str(
+        process.env.OM_ORCAROUTER_BASE_URL,
+        "https://api.orcarouter.ai/v1",
+    ),
+    orcarouter_model: process.env.OM_ORCAROUTER_MODEL,
+    orcarouter_embedding_model: process.env.OM_ORCAROUTER_EMBEDDING_MODEL,
     ollama_url: str(
         process.env.OLLAMA_URL || process.env.OM_OLLAMA_URL,
         "http://localhost:11434",

--- a/packages/openmemory-js/src/core/models.ts
+++ b/packages/openmemory-js/src/core/models.ts
@@ -54,6 +54,7 @@ const get_defaults = (): model_cfg => ({
         gemini: "models/gemini-embedding-001",
         aws: "amazon.titan-embed-text-v2:0",
         siray: "text-embedding-3-small",
+        orcarouter: "orcarouter/auto",
         local: "all-MiniLM-L6-v2",
     },
     semantic: {
@@ -62,6 +63,7 @@ const get_defaults = (): model_cfg => ({
         gemini: "models/gemini-embedding-001",
         aws: "amazon.titan-embed-text-v2:0",
         siray: "text-embedding-3-small",
+        orcarouter: "orcarouter/auto",
         local: "all-MiniLM-L6-v2",
     },
     procedural: {
@@ -69,6 +71,7 @@ const get_defaults = (): model_cfg => ({
         openai: "text-embedding-3-small",
         gemini: "models/gemini-embedding-001",
         aws: "amazon.titan-embed-text-v2:0",
+        orcarouter: "orcarouter/auto",
         local: "all-MiniLM-L6-v2",
     },
     emotional: {
@@ -76,6 +79,7 @@ const get_defaults = (): model_cfg => ({
         openai: "text-embedding-3-small",
         gemini: "models/gemini-embedding-001",
         aws: "amazon.titan-embed-text-v2:0",
+        orcarouter: "orcarouter/auto",
         local: "all-MiniLM-L6-v2",
     },
     reflective: {
@@ -83,6 +87,7 @@ const get_defaults = (): model_cfg => ({
         openai: "text-embedding-3-large",
         gemini: "models/gemini-embedding-001",
         aws: "amazon.titan-embed-text-v2:0",
+        orcarouter: "orcarouter/auto",
         local: "all-mpnet-base-v2",
     },
 });
@@ -93,6 +98,9 @@ export const get_model = (sector: string, provider: string): string => {
     }
     if (provider === "openai" && process.env.OM_OPENAI_MODEL) {
         return process.env.OM_OPENAI_MODEL;
+    }
+    if (provider === "orcarouter" && process.env.OM_ORCAROUTER_EMBEDDING_MODEL) {
+        return process.env.OM_ORCAROUTER_EMBEDDING_MODEL;
     }
 
     const cfg = load_models();

--- a/packages/openmemory-js/src/memory/embed.ts
+++ b/packages/openmemory-js/src/memory/embed.ts
@@ -146,6 +146,8 @@ async function embed_with_provider(
             return gen_syn_emb(t, s);
         case "siray":
             return await emb_siray(t, s);
+        case "orcarouter":
+            return await emb_orcarouter(t, s);
         default:
             throw new Error(`Unknown embedding provider: ${provider}`);
     }
@@ -199,6 +201,9 @@ async function emb_batch_with_fallback(
                     break;
                 case "openai":
                     result = await emb_batch_openai(txts);
+                    break;
+                case "orcarouter":
+                    result = await emb_batch_orcarouter(txts);
                     break;
                 default:
                     result = {};
@@ -424,6 +429,57 @@ async function emb_siray(t: string, s: string): Promise<number[]> {
     return ((await r.json()) as any).data[0].embedding;
 }
 
+async function emb_orcarouter(t: string, s: string): Promise<number[]> {
+    if (!env.orcarouter_key) throw new Error("OrcaRouter key missing");
+    const m = get_model(s, "orcarouter");
+
+    const r = await fetchWithTimeout(
+        `${env.orcarouter_base_url.replace(/\/$/, "")}/embeddings`,
+        {
+            method: "POST",
+            headers: {
+                "content-type": "application/json",
+                authorization: `Bearer ${env.orcarouter_key}`,
+            },
+            body: JSON.stringify({
+                input: t,
+                model: env.orcarouter_embedding_model || m,
+                ...(env.vec_dim ? { dimensions: env.vec_dim } : {}),
+            }),
+        },
+    );
+    if (!r.ok) throw new Error(`OrcaRouter: ${r.status}`);
+    return ((await r.json()) as any).data[0].embedding;
+}
+
+async function emb_batch_orcarouter(
+    txts: Record<string, string>,
+): Promise<Record<string, number[]>> {
+    if (!env.orcarouter_key) throw new Error("OrcaRouter key missing");
+    const secs = Object.keys(txts),
+        m = get_model("semantic", "orcarouter");
+    const r = await fetchWithTimeout(
+        `${env.orcarouter_base_url.replace(/\/$/, "")}/embeddings`,
+        {
+            method: "POST",
+            headers: {
+                "content-type": "application/json",
+                authorization: `Bearer ${env.orcarouter_key}`,
+            },
+            body: JSON.stringify({
+                input: Object.values(txts),
+                model: env.orcarouter_embedding_model || m,
+                ...(env.vec_dim ? { dimensions: env.vec_dim } : {}),
+            }),
+        },
+    );
+    if (!r.ok) throw new Error(`OrcaRouter batch: ${r.status}`);
+    const d = (await r.json()) as any,
+        out: Record<string, number[]> = {};
+    secs.forEach((s, i) => (out[s] = d.data[i].embedding));
+    return out;
+}
+
 async function emb_local(t: string, s: string): Promise<number[]> {
     if (!env.local_model_path) {
         console.error("[EMBED] Local model missing, using synthetic");
@@ -578,7 +634,9 @@ export async function embedMultiSector(
             const simp = env.embed_mode === "simple";
             if (
                 simp &&
-                (env.emb_kind === "gemini" || env.emb_kind === "openai")
+                (env.emb_kind === "gemini" ||
+                    env.emb_kind === "openai" ||
+                    env.emb_kind === "orcarouter")
             ) {
                 console.error(
                     `[EMBED] Simple mode (1 batch for ${secs.length} sectors)`,
@@ -683,7 +741,9 @@ export const getEmbeddingInfo = () => {
         mode: env.embed_mode,
         batch_support:
             env.embed_mode === "simple" &&
-            (env.emb_kind === "gemini" || env.emb_kind === "openai"),
+            (env.emb_kind === "gemini" ||
+                env.emb_kind === "openai" ||
+                env.emb_kind === "orcarouter"),
         advanced_parallel: env.adv_embed_parallel,
         embed_delay_ms: env.embed_delay_ms,
     };
@@ -719,6 +779,17 @@ export const getEmbeddingInfo = () => {
             procedural: get_model("procedural", "siray"),
             emotional: get_model("emotional", "siray"),
             reflective: get_model("reflective", "siray"),
+        };
+    } else if (env.emb_kind === "orcarouter") {
+        i.configured = !!env.orcarouter_key;
+        i.base_url = env.orcarouter_base_url;
+        i.model_override = env.orcarouter_embedding_model || null;
+        i.models = {
+            episodic: get_model("episodic", "orcarouter"),
+            semantic: get_model("semantic", "orcarouter"),
+            procedural: get_model("procedural", "orcarouter"),
+            emotional: get_model("emotional", "orcarouter"),
+            reflective: get_model("reflective", "orcarouter"),
         };
     } else if (env.emb_kind === "ollama") {
         i.configured = true;

--- a/packages/openmemory-js/tests/orcarouter.test.ts
+++ b/packages/openmemory-js/tests/orcarouter.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
+import { get_model } from "../src/core/models";
+
+describe("orcarouter provider wiring", () => {
+    let env: any;
+    let getEmbeddingInfo: any;
+    let getEmbeddingProvider: any;
+
+    beforeAll(async () => {
+        // Set env BEFORE evaluating cfg.ts. vi.resetModules() forces a fresh
+        // module registry so the singleton cfg object reads the orcarouter
+        // settings instead of the CI default (synthetic).
+        vi.resetModules();
+        process.env.OM_EMBEDDINGS = "orcarouter";
+        process.env.ORCAROUTER_API_KEY = "sk-orca-test";
+        process.env.OM_ORCAROUTER_BASE_URL = "https://api.orcarouter.ai/v1";
+        process.env.OM_ORCAROUTER_EMBEDDING_MODEL = "orcarouter/auto";
+        process.env.OM_EMBED_MODE = "simple";
+        const cfg = await import("../src/core/cfg");
+        const embed = await import("../src/memory/embed");
+        env = cfg.env;
+        getEmbeddingInfo = embed.getEmbeddingInfo;
+        getEmbeddingProvider = embed.getEmbeddingProvider;
+    });
+
+    afterAll(() => {
+        // Restore the environment so later test files (single-fork) see the
+        // CI defaults, not the orcarouter settings from this file.
+        delete process.env.OM_EMBEDDINGS;
+        delete process.env.ORCAROUTER_API_KEY;
+        delete process.env.OM_ORCAROUTER_BASE_URL;
+        delete process.env.OM_ORCAROUTER_EMBEDDING_MODEL;
+        delete process.env.OM_EMBED_MODE;
+    });
+
+    it("env exposes orcarouter config", () => {
+        expect(env.orcarouter_key).toBe("sk-orca-test");
+        expect(env.orcarouter_base_url).toBe("https://api.orcarouter.ai/v1");
+        expect(env.emb_kind).toBe("orcarouter");
+    });
+
+    it("get_model resolves the orcarouter default for every sector", () => {
+        for (const sector of [
+            "episodic",
+            "semantic",
+            "procedural",
+            "emotional",
+            "reflective",
+        ]) {
+            expect(get_model(sector, "orcarouter")).toBe("orcarouter/auto");
+        }
+    });
+
+    it("get_model honors the per-sector override env var", () => {
+        const prev = process.env.OM_ORCAROUTER_EMBEDDING_MODEL;
+        process.env.OM_ORCAROUTER_EMBEDDING_MODEL = "orcarouter/custom";
+        try {
+            expect(get_model("semantic", "orcarouter")).toBe(
+                "orcarouter/custom",
+            );
+        } finally {
+            process.env.OM_ORCAROUTER_EMBEDDING_MODEL = prev;
+        }
+    });
+
+    it("reports orcarouter as the active embedding provider", () => {
+        expect(getEmbeddingProvider()).toBe("orcarouter");
+    });
+
+    it("getEmbeddingInfo describes the orcarouter provider", () => {
+        const info = getEmbeddingInfo();
+        expect(info.provider).toBe("orcarouter");
+        expect(info.configured).toBe(true);
+        expect(info.base_url).toBe("https://api.orcarouter.ai/v1");
+        expect(info.models.semantic).toBe("orcarouter/auto");
+        // OrcaRouter supports batch embeddings, so simple mode is batch-capable
+        expect(info.batch_support).toBe(true);
+    });
+});

--- a/packages/openmemory-py/src/openmemory/ai/__init__.py
+++ b/packages/openmemory-py/src/openmemory/ai/__init__.py
@@ -6,5 +6,6 @@ from .aws import AwsAdapter
 from .synthetic import SyntheticAdapter
 from .siray import SirayAdapter
 from .minimax import MiniMaxAdapter
+from .orcarouter import OrcaRouterAdapter
 
-__all__ = ["AIAdapter", "OpenAIAdapter", "OllamaAdapter", "GeminiAdapter", "AwsAdapter", "SyntheticAdapter", "SirayAdapter", "MiniMaxAdapter"]
+__all__ = ["AIAdapter", "OpenAIAdapter", "OllamaAdapter", "GeminiAdapter", "AwsAdapter", "SyntheticAdapter", "SirayAdapter", "MiniMaxAdapter", "OrcaRouterAdapter"]

--- a/packages/openmemory-py/src/openmemory/ai/orcarouter.py
+++ b/packages/openmemory-py/src/openmemory/ai/orcarouter.py
@@ -1,0 +1,38 @@
+import os
+from typing import List, Dict, Any, Optional
+from openai import AsyncOpenAI
+from ..core.config import env
+from .adapter import AIAdapter
+
+
+class OrcaRouterAdapter(AIAdapter):
+    """OrcaRouter adapter for chat completions and embeddings.
+
+    OrcaRouter exposes an OpenAI-compatible API gateway at
+    https://api.orcarouter.ai/v1. It also runs gateway-level, zero-trust
+    security for AI agents on the same endpoint.
+    """
+
+    def __init__(self, api_key: str = None, base_url: str = None):
+        self.api_key = api_key or env.orcarouter_key
+        self.base_url = base_url or env.orcarouter_base_url
+        self.client = AsyncOpenAI(api_key=self.api_key, base_url=self.base_url)
+
+    async def chat(self, messages: List[Dict[str, str]], model: str = None, **kwargs) -> str:
+        m = model or env.orcarouter_model or "orcarouter/auto"
+        res = await self.client.chat.completions.create(
+            model=m,
+            messages=messages,
+            **kwargs
+        )
+        return res.choices[0].message.content or ""
+
+    async def embed(self, text: str, model: str = None) -> List[float]:
+        m = model or env.orcarouter_embedding_model or "orcarouter/auto"
+        res = await self.client.embeddings.create(input=text, model=m)
+        return res.data[0].embedding
+
+    async def embed_batch(self, texts: List[str], model: str = None) -> List[List[float]]:
+        m = model or env.orcarouter_embedding_model or "orcarouter/auto"
+        res = await self.client.embeddings.create(input=texts, model=m)
+        return [d.embedding for d in res.data]

--- a/packages/openmemory-py/src/openmemory/core/config.py
+++ b/packages/openmemory-py/src/openmemory/core/config.py
@@ -68,6 +68,11 @@ class EnvConfig:
         self.minimax_model = get("ai", "minimax_model", "OM_MINIMAX_MODEL", None)
         self.minimax_embedding_model = os.getenv("OM_MINIMAX_EMBEDDING_MODEL")
 
+        self.orcarouter_key = get("ai", "orcarouter_key", "ORCAROUTER_API_KEY", "") or os.getenv("OM_ORCAROUTER_API_KEY")
+        self.orcarouter_base_url = get("ai", "orcarouter_base", "OM_ORCAROUTER_BASE_URL", "https://api.orcarouter.ai/v1")
+        self.orcarouter_model = get("ai", "orcarouter_model", "OM_ORCAROUTER_MODEL", None)
+        self.orcarouter_embedding_model = os.getenv("OM_ORCAROUTER_EMBEDDING_MODEL")
+
         self.vec_dim = int(num(os.getenv("OM_VEC_DIM"), 1536))
         self.min_score = num(os.getenv("OM_MIN_SCORE"), 0.3)
         self.keyword_boost = num(os.getenv("OM_KEYWORD_BOOST"), 2.5)

--- a/packages/openmemory-py/src/openmemory/memory/embed.py
+++ b/packages/openmemory-py/src/openmemory/memory/embed.py
@@ -20,6 +20,7 @@ from ..ai.gemini import GeminiAdapter
 from ..ai.aws import AwsAdapter
 from ..ai.synthetic import SyntheticAdapter
 from ..ai.minimax import MiniMaxAdapter
+from ..ai.orcarouter import OrcaRouterAdapter
 
 async def emb_dispatch(provider: str, t: str, s: str) -> List[float]:
     if provider == "synthetic":
@@ -34,6 +35,8 @@ async def emb_dispatch(provider: str, t: str, s: str) -> List[float]:
         return await AwsAdapter().embed(t, model=env.aws_embedding_model)
     if provider == "minimax":
         return await MiniMaxAdapter().embed(t, model=env.minimax_embedding_model)
+    if provider == "orcarouter":
+        return await OrcaRouterAdapter().embed(t, model=env.orcarouter_embedding_model)
 
     return await SyntheticAdapter(env.vec_dim or 768).embed(t, model=s)
 

--- a/packages/openmemory-py/tests/test_orcarouter.py
+++ b/packages/openmemory-py/tests/test_orcarouter.py
@@ -1,0 +1,272 @@
+"""Tests for OrcaRouter AI adapter (chat + embeddings)."""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+from openmemory.ai.orcarouter import OrcaRouterAdapter
+
+
+# ---------------------------------------------------------------------------
+# Unit tests – mock all external calls
+# ---------------------------------------------------------------------------
+
+
+class TestOrcaRouterAdapterInit:
+    """Test adapter initialization."""
+
+    def test_default_init(self):
+        with patch("openmemory.ai.orcarouter.env") as mock_env:
+            mock_env.orcarouter_key = "sk-orca-test-key"
+            mock_env.orcarouter_base_url = "https://api.orcarouter.ai/v1"
+            adapter = OrcaRouterAdapter()
+            assert adapter.api_key == "sk-orca-test-key"
+            assert adapter.base_url == "https://api.orcarouter.ai/v1"
+
+    def test_custom_init(self):
+        adapter = OrcaRouterAdapter(api_key="custom-key", base_url="https://custom.api/v1")
+        assert adapter.api_key == "custom-key"
+        assert adapter.base_url == "https://custom.api/v1"
+
+    def test_api_key_override(self):
+        with patch("openmemory.ai.orcarouter.env") as mock_env:
+            mock_env.orcarouter_key = "env-key"
+            mock_env.orcarouter_base_url = "https://api.orcarouter.ai/v1"
+            adapter = OrcaRouterAdapter(api_key="override-key")
+            assert adapter.api_key == "override-key"
+
+
+class TestOrcaRouterChat:
+    """Test chat completion."""
+
+    @pytest.mark.asyncio
+    async def test_chat_basic(self):
+        adapter = OrcaRouterAdapter(api_key="test", base_url="https://api.orcarouter.ai/v1")
+
+        mock_choice = MagicMock()
+        mock_choice.message.content = "Hello from OrcaRouter!"
+        mock_response = MagicMock()
+        mock_response.choices = [mock_choice]
+
+        adapter.client = AsyncMock()
+        adapter.client.chat.completions.create = AsyncMock(return_value=mock_response)
+
+        result = await adapter.chat([{"role": "user", "content": "Hi"}])
+        assert result == "Hello from OrcaRouter!"
+        adapter.client.chat.completions.create.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_chat_default_model(self):
+        adapter = OrcaRouterAdapter(api_key="test", base_url="https://api.orcarouter.ai/v1")
+
+        mock_choice = MagicMock()
+        mock_choice.message.content = "response"
+        mock_response = MagicMock()
+        mock_response.choices = [mock_choice]
+
+        adapter.client = AsyncMock()
+        adapter.client.chat.completions.create = AsyncMock(return_value=mock_response)
+
+        with patch("openmemory.ai.orcarouter.env") as mock_env:
+            mock_env.orcarouter_model = None
+            await adapter.chat([{"role": "user", "content": "test"}])
+
+        call_kwargs = adapter.client.chat.completions.create.call_args
+        assert call_kwargs.kwargs["model"] == "orcarouter/auto"
+
+    @pytest.mark.asyncio
+    async def test_chat_custom_model(self):
+        adapter = OrcaRouterAdapter(api_key="test", base_url="https://api.orcarouter.ai/v1")
+
+        mock_choice = MagicMock()
+        mock_choice.message.content = "response"
+        mock_response = MagicMock()
+        mock_response.choices = [mock_choice]
+
+        adapter.client = AsyncMock()
+        adapter.client.chat.completions.create = AsyncMock(return_value=mock_response)
+
+        await adapter.chat(
+            [{"role": "user", "content": "test"}],
+            model="orcarouter/some-model",
+        )
+        call_kwargs = adapter.client.chat.completions.create.call_args
+        assert call_kwargs.kwargs["model"] == "orcarouter/some-model"
+
+    @pytest.mark.asyncio
+    async def test_chat_none_content_returns_empty(self):
+        adapter = OrcaRouterAdapter(api_key="test", base_url="https://api.orcarouter.ai/v1")
+
+        mock_choice = MagicMock()
+        mock_choice.message.content = None
+        mock_response = MagicMock()
+        mock_response.choices = [mock_choice]
+
+        adapter.client = AsyncMock()
+        adapter.client.chat.completions.create = AsyncMock(return_value=mock_response)
+
+        result = await adapter.chat([{"role": "user", "content": "test"}])
+        assert result == ""
+
+
+class TestOrcaRouterEmbed:
+    """Test embedding methods."""
+
+    @pytest.mark.asyncio
+    async def test_embed_single(self):
+        adapter = OrcaRouterAdapter(api_key="test", base_url="https://api.orcarouter.ai/v1")
+
+        mock_choice = MagicMock()
+        mock_choice.embedding = [0.1, 0.2, 0.3] * 512  # 1536 dims
+        mock_response = MagicMock()
+        mock_response.data = [mock_choice]
+
+        adapter.client = AsyncMock()
+        adapter.client.embeddings.create = AsyncMock(return_value=mock_response)
+
+        result = await adapter.embed("hello world")
+        assert len(result) == 1536
+
+    @pytest.mark.asyncio
+    async def test_embed_batch(self):
+        adapter = OrcaRouterAdapter(api_key="test", base_url="https://api.orcarouter.ai/v1")
+
+        mock_choice_1 = MagicMock()
+        mock_choice_1.embedding = [0.1] * 1536
+        mock_choice_2 = MagicMock()
+        mock_choice_2.embedding = [0.2] * 1536
+        mock_response = MagicMock()
+        mock_response.data = [mock_choice_1, mock_choice_2]
+
+        adapter.client = AsyncMock()
+        adapter.client.embeddings.create = AsyncMock(return_value=mock_response)
+
+        result = await adapter.embed_batch(["text1", "text2"])
+        assert len(result) == 2
+        assert all(len(v) == 1536 for v in result)
+
+    @pytest.mark.asyncio
+    async def test_embed_default_model(self):
+        adapter = OrcaRouterAdapter(api_key="test", base_url="https://api.orcarouter.ai/v1")
+
+        mock_choice = MagicMock()
+        mock_choice.embedding = [0.1] * 1536
+        mock_response = MagicMock()
+        mock_response.data = [mock_choice]
+
+        adapter.client = AsyncMock()
+        adapter.client.embeddings.create = AsyncMock(return_value=mock_response)
+
+        with patch("openmemory.ai.orcarouter.env") as mock_env:
+            mock_env.orcarouter_embedding_model = None
+            await adapter.embed("test")
+
+        call_kwargs = adapter.client.embeddings.create.call_args
+        assert call_kwargs.kwargs["model"] == "orcarouter/auto"
+
+    @pytest.mark.asyncio
+    async def test_embed_custom_model(self):
+        adapter = OrcaRouterAdapter(api_key="test", base_url="https://api.orcarouter.ai/v1")
+
+        mock_choice = MagicMock()
+        mock_choice.embedding = [0.1] * 1536
+        mock_response = MagicMock()
+        mock_response.data = [mock_choice]
+
+        adapter.client = AsyncMock()
+        adapter.client.embeddings.create = AsyncMock(return_value=mock_response)
+
+        await adapter.embed("test", model="custom-embed-model")
+        call_kwargs = adapter.client.embeddings.create.call_args
+        assert call_kwargs.kwargs["model"] == "custom-embed-model"
+
+
+class TestOrcaRouterAIAdapterInterface:
+    """Verify OrcaRouterAdapter satisfies AIAdapter interface."""
+
+    def test_is_subclass_of_adapter(self):
+        from openmemory.ai.adapter import AIAdapter
+        assert issubclass(OrcaRouterAdapter, AIAdapter)
+
+    def test_has_required_methods(self):
+        adapter = OrcaRouterAdapter(api_key="test", base_url="https://test.com/v1")
+        assert hasattr(adapter, "chat")
+        assert hasattr(adapter, "embed")
+        assert hasattr(adapter, "embed_batch")
+        assert callable(adapter.chat)
+        assert callable(adapter.embed)
+        assert callable(adapter.embed_batch)
+
+
+class TestOrcaRouterConfig:
+    """Test OrcaRouter config integration."""
+
+    def test_config_has_orcarouter_fields(self):
+        from openmemory.core.config import EnvConfig
+        with patch.dict("os.environ", {}, clear=False):
+            cfg = EnvConfig()
+            assert hasattr(cfg, "orcarouter_key")
+            assert hasattr(cfg, "orcarouter_base_url")
+            assert hasattr(cfg, "orcarouter_model")
+            assert hasattr(cfg, "orcarouter_embedding_model")
+
+    def test_config_default_base_url(self):
+        from openmemory.core.config import EnvConfig
+        with patch.dict("os.environ", {}, clear=False):
+            cfg = EnvConfig()
+            assert cfg.orcarouter_base_url == "https://api.orcarouter.ai/v1"
+
+
+class TestOrcaRouterExport:
+    """Test OrcaRouterAdapter is properly exported."""
+
+    def test_exported_from_ai_package(self):
+        from openmemory.ai import OrcaRouterAdapter as Imported
+        assert Imported is OrcaRouterAdapter
+
+    def test_in_all_list(self):
+        from openmemory import ai
+        assert "OrcaRouterAdapter" in ai.__all__
+
+
+class TestEmbedDispatch:
+    """Test embed dispatch includes orcarouter."""
+
+    @pytest.mark.asyncio
+    async def test_orcarouter_dispatch(self):
+        with patch("openmemory.memory.embed.OrcaRouterAdapter") as MockAdapter:
+            mock_instance = AsyncMock()
+            mock_instance.embed = AsyncMock(return_value=[0.1] * 1536)
+            MockAdapter.return_value = mock_instance
+
+            with patch("openmemory.memory.embed.env") as mock_env:
+                mock_env.orcarouter_embedding_model = "orcarouter/auto"
+
+                from openmemory.memory.embed import emb_dispatch
+                result = await emb_dispatch("orcarouter", "test text", "semantic")
+                assert len(result) == 1536
+                mock_instance.embed.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Integration tests – require ORCAROUTER_API_KEY
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+class TestOrcaRouterIntegration:
+    """Integration tests for OrcaRouter (requires ORCAROUTER_API_KEY)."""
+
+    @pytest.mark.asyncio
+    async def test_chat_real_api(self):
+        import os
+        api_key = os.getenv("ORCAROUTER_API_KEY")
+        if not api_key:
+            pytest.skip("ORCAROUTER_API_KEY not set")
+
+        adapter = OrcaRouterAdapter(api_key=api_key)
+        result = await adapter.chat(
+            [{"role": "user", "content": "Say 'hello' and nothing else."}],
+            model="orcarouter/auto",
+            max_tokens=256,
+        )
+        assert isinstance(result, str)
+        assert len(result) > 0


### PR DESCRIPTION
## 📋 Description

Add **[OrcaRouter](https://www.orcarouter.ai)** as a first-class, named embedding provider, mirroring the existing `siray`/`minimax` OpenAI-compatible adapter pattern.

OrcaRouter is an OpenAI-compatible AI gateway at `https://api.orcarouter.ai/v1` (API keys start with `sk-orca-`). It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

**Python SDK (`openmemory-py`)**
- New `OrcaRouterAdapter` (chat + single/batch embeddings via the OpenAI-compatible API)
- Env config: `ORCAROUTER_API_KEY`, `OM_ORCAROUTER_BASE_URL` (default `https://api.orcarouter.ai/v1`), `OM_ORCAROUTER_MODEL`, `OM_ORCAROUTER_EMBEDDING_MODEL`
- `emb_dispatch()` routes the `orcarouter` provider

**JS SDK / server (`openmemory-js`)**
- `env` exposes orcarouter settings (base URL defaults to `https://api.orcarouter.ai/v1`)
- `emb_orcarouter()` / `emb_batch_orcarouter()` for single and batch embeddings
- `get_model()` resolves per-sector defaults from `models.yml`
- `getEmbeddingInfo()` reports orcarouter config; simple-mode batch path enabled

**Dashboard**
- Settings page lists `orcarouter` in the embedding provider select and adds OrcaRouter base URL / model override / API key fields
- Settings API masks `ORCAROUTER_API_KEY`

**Config / docs**
- `models.yml` per-sector orcarouter defaults
- `.env.example`, `docs/mcp.md`, `README.md` updated

## 🔄 Type of Change
- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 📚 Documentation update
- [x] 🧪 Test updates

## 🧪 Testing
- [x] I have tested this change locally
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Python: `tests/test_orcarouter.py` (18 unit tests) + existing `test_minimax.py` / `test_omnibus.py` all pass (27 passed, 3 skipped — identical to a clean upstream checkout). JS: full `vitest` suite passes (9 files / 47 tests). Live test against the OrcaRouter API (`/v1/chat/completions` + `/v1/embeddings`) returns HTTP 200 with the real key.

## 🔍 Code Review Checklist
- [x] Code follows the project's coding standards
- [x] Self-review of the code has been performed
- [x] Code is properly commented, particularly in hard-to-understand areas
- [x] Changes generate no new warnings
- [x] Any dependent changes have been merged and published

## 📚 Related Issues
N/A

## 🚀 Deployment Notes
No deployment changes required. Users opt in by setting `OM_EMBEDDINGS=orcarouter` and `ORCAROUTER_API_KEY`.

## 📋 Additional Context

Disclosure: I'm an engineer on the OrcaRouter team.
