### PR TITLE
feat: Add support for vector search with Qdrant

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -49,12 +49,18 @@ OM_PG_SSL=disable # disable | require
 # --------------------------------------------
 # Vector Store Backend
 # --------------------------------------------
-# Vector storage follows OM_METADATA_BACKEND (sqlite/postgres) unless set to 'valkey'
-# Options: valkey (Redis-compatible), or leave unset to follow OM_METADATA_BACKEND
+# Options: sqlite | valkey (Redis-compatible) | qdrant, or leave unset to follow OM_METADATA_BACKEND
 # Note: When using postgres metadata backend, vectors are stored in the same database
 OM_VECTOR_BACKEND=sqlite
 # Table name for vectors (configurable, will be created if it doesn't exist)
 OM_VECTOR_TABLE=vectors
+
+# Qdrant Vector Store (used when OM_VECTOR_BACKEND=qdrant)
+QDRANT_URL=http://localhost:6333
+QDRANT_API_KEY=
+# Prefix for Qdrant collections (one collection per sector), e.g. 'openmemory_'
+OM_QDRANT_COLLECTION_PREFIX=openmemory_
+
 OM_WEAVIATE_URL=
 OM_WEAVIATE_API_KEY=
 OM_WEAVIATE_CLASS=OpenMemory

--- a/dashboard/app/settings/page.tsx
+++ b/dashboard/app/settings/page.tsx
@@ -135,7 +135,27 @@ const SETTING_METADATA: Record<string, SettingInfo> = {
         label: 'Vector Store Backend',
         description: 'Storage backend for vector embeddings',
         type: 'select',
-        options: ['sqlite', 'pgvector', 'weaviate']
+        options: ['sqlite', 'pgvector', 'valkey', 'qdrant', 'weaviate']
+    },
+    OM_QDRANT_URL: {
+        category: 'Vectors',
+        label: 'Qdrant URL',
+        description: 'Qdrant server URL (if using Qdrant)',
+        type: 'text',
+        placeholder: 'http://localhost:6333'
+    },
+    OM_QDRANT_API_KEY: {
+        category: 'Vectors',
+        label: 'Qdrant API Key',
+        description: 'Authentication key for Qdrant (if enabled)',
+        type: 'password'
+    },
+    OM_QDRANT_COLLECTION_PREFIX: {
+        category: 'Vectors',
+        label: 'Qdrant Collection Prefix',
+        description: 'Prefix for Qdrant collections (one per sector)',
+        type: 'text',
+        placeholder: 'openmemory_'
     },
     OM_VECTOR_TABLE: {
         category: 'Vectors',

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -76,9 +76,12 @@ services:
       - OM_PG_TABLE=${OM_PG_TABLE:-openmemory_memories}
       - OM_PG_SSL=${OM_PG_SSL:-disable}
 
-      # Vector Backend (follows OM_METADATA_BACKEND unless set to 'valkey')
+      # Vector Backend (follows OM_METADATA_BACKEND unless set to 'valkey' or 'qdrant')
       - OM_VECTOR_BACKEND=${OM_VECTOR_BACKEND:-sqlite}
       - OM_VECTOR_TABLE=${OM_VECTOR_TABLE:-openmemory_vectors}
+      - OM_QDRANT_URL=${OM_QDRANT_URL:-http://qdrant:6333}
+      - OM_QDRANT_API_KEY=${OM_QDRANT_API_KEY:-}
+      - OM_QDRANT_COLLECTION_PREFIX=${OM_QDRANT_COLLECTION_PREFIX:-openmemory_}
       - OM_WEAVIATE_URL=${OM_WEAVIATE_URL:-}
       - OM_WEAVIATE_API_KEY=${OM_WEAVIATE_API_KEY:-}
       - OM_WEAVIATE_CLASS=${OM_WEAVIATE_CLASS:-OpenMemory}
@@ -155,9 +158,24 @@ services:
       retries: 3
       start_period: 30s
 
+  # Optional: Qdrant for vector storage
+  # Set OM_VECTOR_BACKEND=qdrant in your .env (and OM_QDRANT_URL if needed).
+  # qdrant:
+  #   image: qdrant/qdrant:v1.19.0
+  #   ports:
+  #     - '6333:6333'
+  #   volumes:
+  #     - qdrant_data:/qdrant/storage
+  #   restart: unless-stopped
+  #   healthcheck:
+  #     test: ['CMD', 'curl', '-f', 'http://localhost:6333/healthz']
+  #     interval: 30s
+  #     timeout: 10s
+  #     retries: 3
+  #     start_period: 30s
+
   # Optional: Valkey for high-performance vector storage
   # Uncomment to use Valkey instead of SQLite/PostgreSQL for vectors
-  # Don't forget to set OM_VECTOR_BACKEND=valkey in your .env
   # valkey:
   #   image: valkey/valkey:8.0
   #   ports:
@@ -175,6 +193,9 @@ services:
 volumes:
   openmemory_data:
     driver: local
+  # Uncomment if using Qdrant
+  # qdrant_data:
+  #   driver: local
   # Uncomment if using Valkey
   # valkey_data:
   #   driver: local

--- a/packages/openmemory-js/README.md
+++ b/packages/openmemory-js/README.md
@@ -117,8 +117,13 @@ OM_PG_USER=postgres
 OM_PG_PASSWORD=...
 
 # vector backend (optional)
-OM_VECTOR_BACKEND=valkey             # default uses metadata backend
+OM_VECTOR_BACKEND=sqlite             # sqlite | postgres | valkey | qdrant
+# valkey
 OM_VALKEY_URL=redis://localhost:6379
+# qdrant
+QDRANT_URL=http://localhost:6333
+QDRANT_API_KEY=
+OM_QDRANT_COLLECTION_PREFIX=openmemory_
 ```
 
 ### programmatic usage

--- a/packages/openmemory-js/package-lock.json
+++ b/packages/openmemory-js/package-lock.json
@@ -13,6 +13,7 @@
                 "@modelcontextprotocol/sdk": "^1.27.1",
                 "@notionhq/client": "^2.2.0",
                 "@octokit/rest": "^21.0.0",
+                "@qdrant/js-client-rest": "^1.19.0",
                 "cheerio": "^1.0.0",
                 "dotenv": "^16.6.1",
                 "fluent-ffmpeg": "^2.1.3",
@@ -24,6 +25,7 @@
                 "pg": "^8.16.3",
                 "sqlite3": "^5.1.7",
                 "turndown": "^7.2.2",
+                "uuid": "^8.3.2",
                 "ws": "^8.18.3",
                 "zod": "^3.25.76"
             },
@@ -36,6 +38,7 @@
                 "@types/fluent-ffmpeg": "^2.1.26",
                 "@types/node": "^20.19.25",
                 "@types/pg": "^8.15.6",
+                "@types/uuid": "^8.3.4",
                 "@vitest/coverage-v8": "^2.1.9",
                 "prettier": "^3.6.2",
                 "tsx": "^4.20.6",
@@ -1909,6 +1912,32 @@
                 "node": ">=14"
             }
         },
+        "node_modules/@qdrant/js-client-rest": {
+            "version": "1.19.0",
+            "resolved": "https://registry.npmjs.org/@qdrant/js-client-rest/-/js-client-rest-1.19.0.tgz",
+            "integrity": "sha512-1+QLUHsWp+WV4PE35FLnH2ckxotWrQEqi/F3t4goF3cCThR0ZxLVtOC4OoOi/E1iyj/iIYBdbuACWMuQ15NAnA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@qdrant/openapi-typescript-fetch": "1.2.6",
+                "undici": "7.29.0"
+            },
+            "engines": {
+                "node": ">=22.0.0"
+            },
+            "peerDependencies": {
+                "typescript": ">=4.7"
+            }
+        },
+        "node_modules/@qdrant/openapi-typescript-fetch": {
+            "version": "1.2.6",
+            "resolved": "https://registry.npmjs.org/@qdrant/openapi-typescript-fetch/-/openapi-typescript-fetch-1.2.6.tgz",
+            "integrity": "sha512-oQG/FejNpItrxRHoyctYvT3rwGZOnK4jr3JdppO/c78ktDvkWiPXPHNsrDf33K9sZdRb6PR7gi4noIapu5q4HA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18.0.0",
+                "pnpm": ">=8"
+            }
+        },
         "node_modules/@rollup/rollup-android-arm-eabi": {
             "version": "4.60.2",
             "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.2.tgz",
@@ -3015,6 +3044,13 @@
                 "pg-protocol": "*",
                 "pg-types": "^2.2.0"
             }
+        },
+        "node_modules/@types/uuid": {
+            "version": "8.3.4",
+            "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
+            "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@vitest/coverage-v8": {
             "version": "2.1.9",
@@ -7547,7 +7583,6 @@
             "version": "5.9.3",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
             "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-            "dev": true,
             "license": "Apache-2.0",
             "bin": {
                 "tsc": "bin/tsc",
@@ -7564,9 +7599,9 @@
             "license": "MIT"
         },
         "node_modules/undici": {
-            "version": "7.16.0",
-            "resolved": "https://registry.npmjs.org/undici/-/undici-7.16.0.tgz",
-            "integrity": "sha512-QEg3HPMll0o3t2ourKwOeUAZ159Kn9mx5pnzHRQO8+Wixmh88YdZRiIwat0iNzNNXn0yoEtXJqFpyW7eM8BV7g==",
+            "version": "7.29.0",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+            "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
             "license": "MIT",
             "engines": {
                 "node": ">=20.18.1"

--- a/packages/openmemory-js/package.json
+++ b/packages/openmemory-js/package.json
@@ -25,6 +25,7 @@
         "@modelcontextprotocol/sdk": "^1.27.1",
         "@notionhq/client": "^2.2.0",
         "@octokit/rest": "^21.0.0",
+        "@qdrant/js-client-rest": "^1.19.0",
         "cheerio": "^1.0.0",
         "dotenv": "^16.6.1",
         "fluent-ffmpeg": "^2.1.3",
@@ -36,6 +37,7 @@
         "pg": "^8.16.3",
         "sqlite3": "^5.1.7",
         "turndown": "^7.2.2",
+        "uuid": "^8.3.2",
         "ws": "^8.18.3",
         "zod": "^3.25.76"
     },
@@ -44,6 +46,7 @@
         "@types/fluent-ffmpeg": "^2.1.26",
         "@types/node": "^20.19.25",
         "@types/pg": "^8.15.6",
+        "@types/uuid": "^8.3.4",
         "@vitest/coverage-v8": "^2.1.9",
         "prettier": "^3.6.2",
         "tsx": "^4.20.6",

--- a/packages/openmemory-js/src/core/cfg.ts
+++ b/packages/openmemory-js/src/core/cfg.ts
@@ -32,10 +32,7 @@ export const env = {
     rate_limit_max_requests: num(process.env.OM_RATE_LIMIT_MAX_REQUESTS, 100),
     compression_enabled: bool(process.env.OM_COMPRESSION_ENABLED),
     compression_algorithm: str(process.env.OM_COMPRESSION_ALGORITHM, "auto") as
-        | "semantic"
-        | "syntactic"
-        | "aggressive"
-        | "auto",
+        "semantic" | "syntactic" | "aggressive" | "auto",
     compression_min_length: num(process.env.OM_COMPRESSION_MIN_LENGTH, 100),
     emb_kind: str(process.env.OM_EMBEDDINGS, "synthetic"),
     embedding_fallback: str(process.env.OM_EMBEDDING_FALLBACK, "synthetic")
@@ -64,7 +61,9 @@ export const env = {
         "https://api.siray.ai/v1",
     ),
     orcarouter_key:
-        process.env.ORCAROUTER_API_KEY || process.env.OM_ORCAROUTER_API_KEY || "",
+        process.env.ORCAROUTER_API_KEY ||
+        process.env.OM_ORCAROUTER_API_KEY ||
+        "",
     orcarouter_base_url: str(
         process.env.OM_ORCAROUTER_BASE_URL,
         "https://api.orcarouter.ai/v1",
@@ -90,13 +89,20 @@ export const env = {
         process.env.OM_METADATA_BACKEND,
         "sqlite",
     ).toLowerCase(),
-    vector_backend: str(
-        process.env.OM_VECTOR_BACKEND,
-        "postgres",
-    ).toLowerCase(),
+    vector_backend: str(process.env.OM_VECTOR_BACKEND, "sqlite").toLowerCase(),
     valkey_host: str(process.env.OM_VALKEY_HOST, "localhost"),
     valkey_port: num(process.env.OM_VALKEY_PORT, 6379),
     valkey_password: process.env.OM_VALKEY_PASSWORD,
+    qdrant_url: str(
+        process.env.OM_QDRANT_URL || process.env.QDRANT_URL,
+        "http://localhost:6333",
+    ),
+    qdrant_api_key:
+        process.env.OM_QDRANT_API_KEY || process.env.QDRANT_API_KEY || "",
+    qdrantCollectionPrefix: str(
+        process.env.OM_QDRANT_COLLECTION_PREFIX,
+        "openmemory_",
+    ),
     ide_mode: bool(process.env.OM_IDE_MODE),
     ide_allowed_origins: str(
         process.env.OM_IDE_ALLOWED_ORIGINS,

--- a/packages/openmemory-js/src/core/db.ts
+++ b/packages/openmemory-js/src/core/db.ts
@@ -6,6 +6,7 @@ import path from "node:path";
 import { VectorStore } from "./vector_store";
 import { PostgresVectorStore } from "./vector/postgres";
 import { ValkeyVectorStore } from "./vector/valkey";
+import { QdrantVectorStore } from "./vector/qdrant";
 import {
     assertSafeIdentifier,
     DbInitError,
@@ -261,7 +262,10 @@ if (is_pg) {
         );
         ready = true;
 
-        if (env.vector_backend === "valkey") {
+        if (env.vector_backend === "qdrant") {
+            vector_store = new QdrantVectorStore();
+            console.error("[DB] Using Qdrant VectorStore");
+        } else if (env.vector_backend === "valkey") {
             vector_store = new ValkeyVectorStore();
             console.error("[DB] Using Valkey VectorStore");
         } else {
@@ -644,7 +648,10 @@ if (is_pg) {
     get_async = one;
     all_async = many;
 
-    if (env.vector_backend === "valkey") {
+    if (env.vector_backend === "qdrant") {
+        vector_store = new QdrantVectorStore();
+        console.error("[DB] Using Qdrant VectorStore");
+    } else if (env.vector_backend === "valkey") {
         vector_store = new ValkeyVectorStore();
         console.error("[DB] Using Valkey VectorStore");
     } else {

--- a/packages/openmemory-js/src/core/vector/qdrant.ts
+++ b/packages/openmemory-js/src/core/vector/qdrant.ts
@@ -1,0 +1,261 @@
+import { v5 as uuidv5 } from "uuid";
+import { QdrantClient } from "@qdrant/js-client-rest";
+import { VectorStore } from "../vector_store";
+import { env } from "../cfg";
+
+// uuid.NAMESPACE_DNS on the Python side.
+const NAMESPACE_DNS = "6ba7b810-9dad-11d1-80b4-00c04fd430c8";
+
+const KNOWN_SECTORS = [
+    "episodic",
+    "semantic",
+    "procedural",
+    "emotional",
+    "reflective",
+    "_mean",
+];
+
+const pointIdToMemId = (pointId: string): string =>
+    pointId.includes(":") ? pointId.split(":").pop()! : pointId;
+
+export interface QdrantVectorStoreOptions {
+    url?: string;
+    apiKey?: string;
+    collectionPrefix?: string;
+}
+
+export class QdrantVectorStore implements VectorStore {
+    private client: QdrantClient;
+    private collectionPrefix: string;
+    private collectionInitialized: Set<string> = new Set();
+
+    constructor(opts: QdrantVectorStoreOptions = {}) {
+        this.client = new QdrantClient({
+            url: opts.url || env.qdrant_url,
+            apiKey: opts.apiKey || env.qdrant_api_key || undefined,
+        });
+        this.collectionPrefix =
+            opts.collectionPrefix ?? env.qdrantCollectionPrefix;
+    }
+
+    private colName(sector: string): string {
+        return `${this.collectionPrefix}${sector}`;
+    }
+
+    private pointId(id: string, sector: string): string {
+        return uuidv5(`openmemory/${sector}:${id}`, NAMESPACE_DNS);
+    }
+
+    private async ensureCollection(sector: string): Promise<void> {
+        const name = this.colName(sector);
+        if (this.collectionInitialized.has(name)) return;
+        if (!(await this.collectionExists(name))) {
+            try {
+                await this.client.createCollection(name, {
+                    vectors: {
+                        size: env.vec_dim,
+                        distance: "Cosine",
+                    },
+                });
+                for (const field of ["user_id", "project_id", "sector"]) {
+                    await this.client
+                        .createPayloadIndex(name, {
+                            field_name: field,
+                            field_schema: "keyword",
+                        })
+                        .catch((e) =>
+                            console.error(
+                                `[Qdrant] Payload index ${field} on ${name} failed: ${e}`,
+                            ),
+                        );
+                }
+                console.error(`[Qdrant] Created collection ${name}`);
+            } catch (e) {
+                if (!(await this.collectionExists(name))) throw e;
+            }
+        }
+        this.collectionInitialized.add(name);
+    }
+
+    async storeVector(
+        id: string,
+        sector: string,
+        vector: number[],
+        dim: number,
+        user_id?: string,
+        project_id?: string,
+    ): Promise<void> {
+        await this.ensureCollection(sector);
+        await this.client.upsert(this.colName(sector), {
+            wait: true,
+            points: [
+                {
+                    id: this.pointId(id, sector),
+                    vector,
+                    payload: {
+                        user_id: user_id || "anonymous",
+                        ...(project_id ? { project_id } : {}),
+                        dim,
+                        sector,
+                        memory_id: id,
+                    },
+                },
+            ],
+        });
+    }
+
+    async deleteVector(id: string, sector: string): Promise<void> {
+        const name = this.colName(sector);
+        if (!(await this.collectionExists(name))) return;
+        await this.client.delete(name, {
+            wait: true,
+            points: [this.pointId(id, sector)],
+        });
+    }
+
+    async deleteVectors(id: string): Promise<void> {
+        for (const sector of KNOWN_SECTORS) {
+            if (await this.collectionExists(this.colName(sector))) {
+                await this.client.delete(this.colName(sector), {
+                    wait: true,
+                    points: [this.pointId(id, sector)],
+                });
+            }
+        }
+    }
+
+    async searchSimilar(
+        sector: string,
+        queryVec: number[],
+        topK: number,
+        user_id?: string,
+        project_id?: string,
+    ): Promise<Array<{ id: string; score: number }>> {
+        const name = this.colName(sector);
+        if (!this.collectionInitialized.has(name)) {
+            if (!(await this.collectionExists(name))) return [];
+            this.collectionInitialized.add(name);
+        }
+        let filter: any;
+        if (user_id || project_id) {
+            filter = {};
+            if (user_id) {
+                filter.must = [{ key: "user_id", match: { value: user_id } }];
+            }
+            if (project_id) {
+                filter.min_should = {
+                    conditions: [
+                        { key: "project_id", match: { value: project_id } },
+                        {
+                            key: "project_id",
+                            match: { value: "system_global" },
+                        },
+                        { key: "project_id", is_empty: true },
+                    ],
+                    min_count: 1,
+                };
+            }
+        }
+        const res = await this.client.query(name, {
+            query: queryVec,
+            limit: topK,
+            with_payload: true,
+            filter,
+        });
+        const out: Array<{ id: string; score: number }> = [];
+        for (const p of res.points) {
+            const memId =
+                p.payload && typeof (p.payload as any).memory_id === "string"
+                    ? (p.payload as any).memory_id
+                    : pointIdToMemId(String(p.id));
+            out.push({ id: memId, score: p.score });
+        }
+        return out;
+    }
+
+    async getVector(
+        id: string,
+        sector: string,
+    ): Promise<{ vector: number[]; dim: number } | null> {
+        const name = this.colName(sector);
+        if (!(await this.collectionExists(name))) return null;
+        const res = await this.client.retrieve(name, {
+            ids: [this.pointId(id, sector)],
+            with_payload: true,
+            with_vector: true,
+        });
+        const p = res[0];
+        if (!p) return null;
+        const vec = Array.isArray(p.vector)
+            ? p.vector
+            : Array.isArray((p.vector as any)?.[0])
+              ? ((p.vector as any)[0] as number[])
+              : [];
+        const dim =
+            p.payload && typeof (p.payload as any).dim === "number"
+                ? (p.payload as any).dim
+                : vec.length;
+        return { vector: vec as number[], dim };
+    }
+
+    async getVectorsById(
+        id: string,
+    ): Promise<Array<{ sector: string; vector: number[]; dim: number }>> {
+        const out: Array<{
+            sector: string;
+            vector: number[];
+            dim: number;
+        }> = [];
+        for (const sector of KNOWN_SECTORS) {
+            const v = await this.getVector(id, sector);
+            if (v) out.push({ sector, ...v });
+        }
+        return out;
+    }
+
+    async getVectorsBySector(
+        sector: string,
+    ): Promise<Array<{ id: string; vector: number[]; dim: number }>> {
+        const name = this.colName(sector);
+        if (!this.collectionInitialized.has(name)) {
+            if (!(await this.collectionExists(name))) return [];
+            this.collectionInitialized.add(name);
+        }
+        const out: Array<{ id: string; vector: number[]; dim: number }> = [];
+        let offset: any;
+        do {
+            const page = await this.client.scroll(name, {
+                limit: 1000,
+                offset: offset as any,
+                with_payload: true,
+                with_vector: true,
+            });
+            for (const p of page.points) {
+                const payload = p.payload as any;
+                if (typeof payload?.memory_id !== "string") {
+                    continue;
+                }
+                const vec = Array.isArray(p.vector)
+                    ? p.vector
+                    : Array.isArray((p.vector as any)?.[0])
+                      ? ((p.vector as any)[0] as number[])
+                      : [];
+                out.push({
+                    id: payload.memory_id,
+                    vector: vec as number[],
+                    dim:
+                        typeof payload.dim === "number"
+                            ? payload.dim
+                            : vec.length,
+                });
+            }
+            offset = page.next_page_offset;
+        } while (offset);
+        return out;
+    }
+
+    private async collectionExists(name: string): Promise<boolean> {
+        const res = await this.client.collectionExists(name);
+        return res.exists;
+    }
+}

--- a/packages/openmemory-py/pyproject.toml
+++ b/packages/openmemory-py/pyproject.toml
@@ -22,6 +22,9 @@ dependencies = [
     "mammoth>=1.6",
     "markdownify>=0.11",
     "openai>=1.0",
+    "python-dotenv>=1.0",
+    "pyyaml>=6.0",
+    "qdrant-client>=1.19.0",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/packages/openmemory-py/src/openmemory/core/vector/__init__.py
+++ b/packages/openmemory-py/src/openmemory/core/vector/__init__.py
@@ -1,3 +1,5 @@
 
 from .postgres import PostgresVectorStore
 from .valkey import ValkeyVectorStore
+
+from .qdrant import QdrantVectorStore

--- a/packages/openmemory-py/src/openmemory/core/vector/qdrant.py
+++ b/packages/openmemory-py/src/openmemory/core/vector/qdrant.py
@@ -1,0 +1,201 @@
+import logging
+import os
+import uuid
+from typing import List, Optional, Dict, Any
+
+from ..vector_store import VectorStore, VectorRow
+from ..config import env
+
+logger = logging.getLogger("vector_store.qdrant")
+
+KNOWN_SECTORS = [
+    "episodic",
+    "semantic",
+    "procedural",
+    "emotional",
+    "reflective",
+    "_mean",
+]
+
+
+def _point_uuid(memory_id: str, sector: str) -> str:
+    return str(
+        uuid.uuid5(uuid.NAMESPACE_DNS, f"openmemory/{sector}:{memory_id}")
+    )
+
+
+class QdrantVectorStore(VectorStore):
+    def __init__(
+        self,
+        url: Optional[str] = None,
+        api_key: Optional[str] = None,
+        collection_prefix: Optional[str] = None,
+    ):
+        self.url = (
+            url
+            or os.getenv("OM_QDRANT_URL")
+            or os.getenv("QDRANT_URL")
+            or "http://localhost:6333"
+        )
+        self.api_key = (
+            api_key
+            or os.getenv("OM_QDRANT_API_KEY")
+            or os.getenv("QDRANT_API_KEY")
+            or None
+        )
+        self.collection_prefix = (
+            collection_prefix
+            if collection_prefix is not None
+            else os.getenv("OM_QDRANT_COLLECTION_PREFIX", "openmemory_")
+        )
+        self.client = None
+        self._initialized: set = set()
+
+    async def _get_client(self):
+        if self.client is None:
+            from qdrant_client import AsyncQdrantClient
+
+            if self.api_key:
+                self.client = AsyncQdrantClient(
+                    url=self.url, api_key=self.api_key
+                )
+            else:
+                self.client = AsyncQdrantClient(url=self.url)
+        return self.client
+
+    def _col(self, sector: str) -> str:
+        return f"{self.collection_prefix}{sector}"
+
+    async def _ensure_collection(self, sector: str):
+        name = self._col(sector)
+        if name in self._initialized:
+            return
+        client = await self._get_client()
+        if not await client.collection_exists(name):
+            try:
+                from qdrant_client import models
+
+                await client.create_collection(
+                    collection_name=name,
+                    vectors_config=models.VectorParams(
+                        size=int(env.vec_dim),
+                        distance=models.Distance.COSINE,
+                    ),
+                )
+                for field in ("user_id", "sector"):
+                    try:
+                        await client.create_payload_index(
+                            collection_name=name,
+                            field_name=field,
+                            field_schema="keyword",
+                        )
+                    except Exception as e:
+                        logger.warning(
+                            "Payload index %s on %s failed: %s", field, name, e
+                        )
+                logger.info("Created Qdrant collection %s", name)
+            except Exception:
+                if not await client.collection_exists(name):
+                    raise
+        self._initialized.add(name)
+
+    async def storeVector(
+        self,
+        id: str,
+        sector: str,
+        vector: List[float],
+        dim: int,
+        user_id: Optional[str] = None,
+    ):
+        client = await self._get_client()
+        await self._ensure_collection(sector)
+        await client.upsert(
+            collection_name=self._col(sector),
+            points=[
+                {
+                    "id": _point_uuid(id, sector),
+                    "vector": list(vector),
+                    "payload": {
+                        "user_id": user_id or "anonymous",
+                        "dim": dim,
+                        "sector": sector,
+                        "memory_id": id,
+                    },
+                }
+            ],
+            wait=True,
+        )
+
+    async def getVectorsById(self, id: str) -> List[VectorRow]:
+        out = []
+        for sector in KNOWN_SECTORS:
+            row = await self.getVector(id, sector)
+            if row:
+                out.append(row)
+        return out
+
+    async def getVector(self, id: str, sector: str) -> Optional[VectorRow]:
+        client = await self._get_client()
+        name = self._col(sector)
+        if not await client.collection_exists(name):
+            return None
+        res = await client.retrieve(
+            collection_name=name,
+            ids=[_point_uuid(id, sector)],
+            with_vectors=True,
+            with_payload=True,
+        )
+        if not res:
+            return None
+        p = res[0]
+        vec = p.vector
+        if isinstance(vec, dict) and "default" in vec:
+            vec = vec["default"]
+        vec = list(vec)
+        payload = p.payload or {}
+        dim = payload.get("dim")
+        if not dim:
+            dim = len(vec)
+        return VectorRow(id, sector, vec, dim)
+
+    async def deleteVectors(self, id: str):
+        client = await self._get_client()
+        for sector in KNOWN_SECTORS:
+            name = self._col(sector)
+            if not await client.collection_exists(name):
+                continue
+            await client.delete(
+                collection_name=name,
+                points_selector=[_point_uuid(id, sector)],
+                wait=True,
+            )
+
+    async def search(
+        self,
+        vector: List[float],
+        sector: str,
+        k: int,
+        filter: Optional[Dict[str, Any]] = None,
+    ) -> List[Dict[str, Any]]:
+        client = await self._get_client()
+        name = self._col(sector)
+        if not await client.collection_exists(name):
+            return []
+        must = []
+        if filter and filter.get("user_id"):
+            must.append(
+                {"key": "user_id", "match": {"value": filter["user_id"]}}
+            )
+        res = await client.query_points(
+            collection_name=name,
+            query=list(vector),
+            limit=k,
+            with_payload=True,
+            query_filter={"must": must} if must else None,
+        )
+        out = []
+        for p in res.points:
+            payload = p.payload or {}
+            mem_id = payload.get("memory_id") or str(p.id)
+            out.append({"id": mem_id, "similarity": float(p.score)})
+        return out

--- a/packages/openmemory-py/src/openmemory/core/vector_store.py
+++ b/packages/openmemory-py/src/openmemory/core/vector_store.py
@@ -90,13 +90,29 @@ class SQLiteVectorStore(VectorStore):
 import os
 
 def get_vector_store() -> VectorStore:
-    backend = os.getenv("OPENMEMORY_VECTOR_STORE", "sqlite")
+    backend = (
+        os.getenv("OM_VECTOR_BACKEND")
+        or os.getenv("OPENMEMORY_VECTOR_STORE")
+        or "sqlite"
+    ).strip().lower()
 
     if backend == "postgres":
         dsn = os.getenv("OPENMEMORY_PG_DSN", "postgresql://user:pass@localhost:5432/db")
         from .vector.postgres import PostgresVectorStore
         logger.info(f"Using PostgresVectorStore at {dsn}")
         return PostgresVectorStore(dsn)
+
+    elif backend == "qdrant":
+        url = (
+            os.getenv("OM_QDRANT_URL")
+            or os.getenv("QDRANT_URL")
+            or "http://localhost:6333"
+        )
+        api_key = os.getenv("OM_QDRANT_API_KEY") or os.getenv("QDRANT_API_KEY") or None
+        prefix = os.getenv("OM_QDRANT_COLLECTION_PREFIX", "openmemory_")
+        from .vector.qdrant import QdrantVectorStore
+        logger.info(f"Using QdrantVectorStore at {url}")
+        return QdrantVectorStore(url, api_key=api_key, collection_prefix=prefix)
 
     elif backend == "valkey" or backend == "redis":
         url = os.getenv("OPENMEMORY_REDIS_URL", "redis://localhost:6379/0")

--- a/packages/openmemory-py/src/openmemory/main.py
+++ b/packages/openmemory-py/src/openmemory/main.py
@@ -35,12 +35,24 @@ class Memory:
 
     async def delete(self, memory_id: str):
         q.del_mem(memory_id)
+        from .core.vector_store import vector_store as store
+        try:
+            await store.deleteVectors(memory_id)
+        except Exception as e:
+            logger.warning(f"vector cleanup failed for {memory_id}: {e}")
         clear_cache()
 
     async def delete_all(self, user_id: str = None):
         uid = user_id or self.default_user
         if uid:
+            ids = [r["id"] for r in q.all_mem_by_user(uid, 1_000_000, 0)]
             q.del_mem_by_user(uid)
+            from .core.vector_store import vector_store as store
+            for mid in ids:
+                try:
+                    await store.deleteVectors(mid)
+                except Exception as e:
+                    logger.warning(f"vector cleanup failed for {mid}: {e}")
             clear_cache(uid)
         else:
             # If no user_id is provided at all, clear everything? 


### PR DESCRIPTION
## Description

This PR adds support for using Qdrant as a vector search provider in OpenMemory.

[Qdrant](https://qdrant.tech/) is an open-source vector search engine built for high-performance and massive scale.

### Testing

I've unit tested this integration against a local Qdrant instance.

### Setup

You can run Qdrant with 

```bash
docker run -p 6333:6333 qdrant/qdrant
```

The dashboard is accessible at http://localhost:6333/dashboard

The `OM_VECTOR_BACKEND` and `QDRANT_URL` can then be set to `qdrant` and `http://localhost:6333` respectively.