### PR TITLE
fix(memory): preserve long single-sentence summaries

### DIFF
--- a/packages/openmemory-js/src/memory/hsg.ts
+++ b/packages/openmemory-js/src/memory/hsg.ts
@@ -455,7 +455,13 @@ export function extract_essence(
 
     selected.sort((a, b) => a.idx - b.idx);
 
-    return selected.map((s) => s.text).join(" ");
+    const essence = selected.map((s) => s.text).join(" ");
+
+    // A single sentence can be longer than max_len, especially for text that
+    // does not put whitespace after punctuation. In that case no sentence is
+    // selected, but summary mode must never replace the source with an empty
+    // string.
+    return essence || raw.slice(0, max_len);
 }
 export function compute_token_overlap(
     q_toks: Set<string>,

--- a/packages/openmemory-js/tests/extract_essence.test.ts
+++ b/packages/openmemory-js/tests/extract_essence.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { extract_essence } from "../src/memory/hsg";
+
+describe("extract_essence", () => {
+    it("falls back to a prefix when a single sentence exceeds the limit", () => {
+        const raw =
+            "This sentence has no terminator and is intentionally longer than the configured summary length";
+
+        expect(extract_essence(raw, "semantic", 40)).toBe(raw.slice(0, 40));
+    });
+
+    it("does not return an empty summary for Chinese text without spaces", () => {
+        const raw =
+            "这是一条没有空格的长中文记忆，它包含多个短句。但是分句后仍可能被当成一个整体，因此摘要不能变成空字符串。";
+
+        expect(extract_essence(raw, "semantic", 30)).toBe(raw.slice(0, 30));
+    });
+});


### PR DESCRIPTION
## Summary

- fall back to the source prefix when essence extraction selects no sentence
- prevent summary-only mode from silently storing an empty memory
- add regressions for a long sentence without a terminator and Chinese text without spaces

## Root cause

`extract_essence()` splits only on English punctuation followed by whitespace. A long single sentence, including common Chinese text without whitespace after punctuation, remains one item. When that item exceeds `max_len`, the first-sentence branch rejects it and the selection loop skips index 0, so the function returns an empty string.

The fallback preserves the existing scoring behavior while guaranteeing that summary-only mode never destroys all source content.

## Verification

- rebased onto the latest upstream `main` (`7a5e7c8`)
- `vitest run`: 10 files, 49 tests passed
- `tsc --noEmit -p tsconfig.json`: passed