### PR TITLE
fix(embeddings): honor an empty fallback chain

### DIFF
--- a/packages/openmemory-js/src/core/cfg.ts
+++ b/packages/openmemory-js/src/core/cfg.ts
@@ -38,7 +38,7 @@ export const env = {
         | "auto",
     compression_min_length: num(process.env.OM_COMPRESSION_MIN_LENGTH, 100),
     emb_kind: str(process.env.OM_EMBEDDINGS, "synthetic"),
-    embedding_fallback: str(process.env.OM_EMBEDDING_FALLBACK, "synthetic")
+    embedding_fallback: (process.env.OM_EMBEDDING_FALLBACK ?? "synthetic")
         .split(",")
         .map((s) => s.trim())
         .filter(Boolean),

--- a/packages/openmemory-js/src/memory/embed.ts
+++ b/packages/openmemory-js/src/memory/embed.ts
@@ -155,6 +155,7 @@ async function embed_with_provider(
 
 async function get_sem_emb(t: string, s: string): Promise<number[]> {
     const providers = [...new Set([env.emb_kind, ...env.embedding_fallback])];
+    let lastError: unknown = new Error("No embedding provider configured");
 
     for (let i = 0; i < providers.length; i++) {
         const provider = providers[i];
@@ -167,6 +168,7 @@ async function get_sem_emb(t: string, s: string): Promise<number[]> {
             }
             return result;
         } catch (e) {
+            lastError = e;
             const errMsg = e instanceof Error ? e.message : String(e);
             const nextProvider = providers[i + 1];
 
@@ -176,20 +178,21 @@ async function get_sem_emb(t: string, s: string): Promise<number[]> {
                 );
             } else {
                 console.error(
-                    `[EMBED] All providers failed. Last error (${provider}): ${errMsg}. Using synthetic.`,
+                    `[EMBED] All providers failed. Last error (${provider}): ${errMsg}.`,
                 );
-                return gen_syn_emb(t, s);
+                throw e;
             }
         }
     }
 
-    return gen_syn_emb(t, s);
+    throw lastError;
 }
 
 async function emb_batch_with_fallback(
     txts: Record<string, string>,
 ): Promise<Record<string, number[]>> {
     const providers = [...new Set([env.emb_kind, ...env.embedding_fallback])];
+    let lastError: unknown = new Error("No embedding provider configured");
 
     for (let i = 0; i < providers.length; i++) {
         const provider = providers[i];
@@ -218,6 +221,7 @@ async function emb_batch_with_fallback(
             }
             return result;
         } catch (e) {
+            lastError = e;
             const errMsg = e instanceof Error ? e.message : String(e);
             const nextProvider = providers[i + 1];
 
@@ -227,23 +231,14 @@ async function emb_batch_with_fallback(
                 );
             } else {
                 console.error(
-                    `[EMBED] All providers failed for batch. Last error (${provider}): ${errMsg}. Using synthetic.`,
+                    `[EMBED] All providers failed for batch. Last error (${provider}): ${errMsg}.`,
                 );
-
-                const result: Record<string, number[]> = {};
-                for (const [s, t] of Object.entries(txts)) {
-                    result[s] = gen_syn_emb(t, s);
-                }
-                return result;
+                throw e;
             }
         }
     }
 
-    const result: Record<string, number[]> = {};
-    for (const [s, t] of Object.entries(txts)) {
-        result[s] = gen_syn_emb(t, s);
-    }
-    return result;
+    throw lastError;
 }
 
 async function emb_openai(t: string, s: string): Promise<number[]> {

--- a/packages/openmemory-js/tests/embedding_fallback.test.ts
+++ b/packages/openmemory-js/tests/embedding_fallback.test.ts
@@ -1,0 +1,34 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+async function loadEmbed(fallback: string) {
+    vi.resetModules();
+    vi.stubEnv("OM_TIER", "deep");
+    vi.stubEnv("OM_EMBEDDINGS", "openai");
+    vi.stubEnv("OM_EMBEDDING_FALLBACK", fallback);
+    vi.stubEnv("OPENAI_API_KEY", "");
+    vi.stubEnv("OM_OPENAI_API_KEY", "");
+    return await import("../src/memory/embed");
+}
+
+describe("embedding fallback chain", () => {
+    afterEach(() => {
+        vi.unstubAllEnvs();
+        vi.resetModules();
+    });
+
+    it("throws after the configured providers fail", async () => {
+        const { embedForSector } = await loadEmbed("");
+
+        await expect(
+            embedForSector("remember this", "semantic"),
+        ).rejects.toThrow("OpenAI key missing");
+    });
+
+    it("still uses synthetic vectors when explicitly configured", async () => {
+        const { embedForSector } = await loadEmbed("synthetic");
+
+        await expect(
+            embedForSector("remember this", "semantic"),
+        ).resolves.toHaveLength(1536);
+    });
+});


### PR DESCRIPTION
## Summary

- let `OM_EMBEDDING_FALLBACK=` explicitly disable fallback providers
- throw the final provider error instead of adding an undeclared synthetic fallback
- preserve existing behavior because the unset default remains `synthetic`

## Problem

The fallback parser used `value || "synthetic"`, so an explicitly empty value became `synthetic`. The embedding functions also generated a synthetic vector after every configured provider failed, even when `synthetic` was not in the configured chain. Operators therefore could not choose fail-closed behavior, and a provider outage could silently mix synthetic vectors into a semantic vector index.

## Verification

- regression tests cover both an empty chain and an explicit synthetic fallback
- `vitest run`: 10 files, 49 tests passed
- `tsc --noEmit -p tsconfig.json`: passed
