### PR TITLE
feat(embeddings): accept DashScope API keys

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -99,6 +99,13 @@ OM_EMBED_DELAY_MS=200
 # Model override for all sector embeddings (leave empty to use defaults)
 # OM_OPENAI_MODEL=text-embedding-qwen3-embedding-4b
 
+# Alibaba Cloud Model Studio (Bailian / DashScope) uses the same
+# OpenAI-compatible provider. Set OPENAI_API_KEY and OM_OPENAI_API_KEY empty
+# when using DASHSCOPE_API_KEY so the explicit OpenAI keys keep precedence.
+# DASHSCOPE_API_KEY=your-dashscope-api-key
+# OM_OPENAI_BASE_URL=https://{WorkspaceId}.cn-beijing.maas.aliyuncs.com/compatible-mode/v1
+# OM_OPENAI_MODEL=text-embedding-v4
+
 # OrcaRouter Embeddings (OpenAI-compatible gateway)
 # OM_ORCAROUTER_BASE_URL=https://api.orcarouter.ai/v1
 # Model override for all sector embeddings (leave empty to use defaults)

--- a/dashboard/app/api/settings/route.ts
+++ b/dashboard/app/api/settings/route.ts
@@ -47,6 +47,7 @@ export async function GET() {
 
         const masked = { ...settings }
         if (masked.OPENAI_API_KEY) masked.OPENAI_API_KEY = '***'
+        if (masked.DASHSCOPE_API_KEY) masked.DASHSCOPE_API_KEY = '***'
         if (masked.GEMINI_API_KEY) masked.GEMINI_API_KEY = '***'
         if (masked.AWS_SECRET_ACCESS_KEY) masked.AWS_SECRET_ACCESS_KEY = "***"
         if (masked.OM_API_KEY) masked.OM_API_KEY = '***'

--- a/dashboard/app/settings/page.tsx
+++ b/dashboard/app/settings/page.tsx
@@ -239,6 +239,13 @@ const SETTING_METADATA: Record<string, SettingInfo> = {
         type: 'password',
         placeholder: 'sk-...'
     },
+    DASHSCOPE_API_KEY: {
+        category: 'API Keys',
+        label: 'DashScope API Key',
+        description: 'API key for Alibaba Cloud Model Studio (Bailian)',
+        type: 'password',
+        placeholder: 'sk-...'
+    },
     ORCAROUTER_API_KEY: {
         category: 'API Keys',
         label: 'OrcaRouter API Key',
@@ -651,4 +658,3 @@ export default function settings() {
         </div>
     )
 }
-

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,7 @@ services:
       # OpenAI Provider
       - OPENAI_API_KEY=${OPENAI_API_KEY:-}
       - OM_OPENAI_API_KEY=${OM_OPENAI_API_KEY:-}
+      - DASHSCOPE_API_KEY=${DASHSCOPE_API_KEY:-}
       - OM_OPENAI_BASE_URL=${OM_OPENAI_BASE_URL:-https://api.openai.com/v1}
       - OM_OPENAI_MODEL=${OM_OPENAI_MODEL:-}
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -612,7 +612,7 @@ If `type="factual"` returns no results:
 
 Ensure environment variables are set:
 - Postgres: `OM_PG_HOST`, `OM_PG_DB`, `OM_PG_USER`, `OM_PG_PASSWORD`
-- Embeddings: `OPENAI_API_KEY` (or relevant provider key, e.g. `ORCAROUTER_API_KEY`)
+- Embeddings: `OPENAI_API_KEY` (or a compatible provider key such as `DASHSCOPE_API_KEY` or `ORCAROUTER_API_KEY`)
 
 ## Performance
 

--- a/packages/openmemory-js/README.md
+++ b/packages/openmemory-js/README.md
@@ -97,6 +97,11 @@ OM_EMBEDDINGS=ollama                 # synthetic | openai | gemini | ollama
 OM_OLLAMA_URL=http://localhost:11434
 OM_OLLAMA_MODEL=embeddinggemma       # or nomic-embed-text, mxbai-embed-large
 
+# Alibaba Cloud Model Studio / Bailian through its OpenAI-compatible endpoint
+# DASHSCOPE_API_KEY=your-dashscope-api-key
+# OM_OPENAI_BASE_URL=https://{WorkspaceId}.cn-beijing.maas.aliyuncs.com/compatible-mode/v1
+# OM_OPENAI_MODEL=text-embedding-v4
+
 # openai
 OPENAI_API_KEY=sk-...
 OM_OPENAI_MODEL=text-embedding-3-small

--- a/packages/openmemory-js/src/core/cfg.ts
+++ b/packages/openmemory-js/src/core/cfg.ts
@@ -46,7 +46,10 @@ export const env = {
     adv_embed_parallel: bool(process.env.OM_ADV_EMBED_PARALLEL),
     embed_delay_ms: num(process.env.OM_EMBED_DELAY_MS, 200),
     openai_key:
-        process.env.OPENAI_API_KEY || process.env.OM_OPENAI_API_KEY || "",
+        process.env.OPENAI_API_KEY ||
+        process.env.OM_OPENAI_API_KEY ||
+        process.env.DASHSCOPE_API_KEY ||
+        "",
     openai_base_url: str(
         process.env.OM_OPENAI_BASE_URL,
         "https://api.openai.com/v1",

--- a/packages/openmemory-js/tests/dashscope.test.ts
+++ b/packages/openmemory-js/tests/dashscope.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+async function loadConfig(
+    openaiKey: string,
+    scopedOpenaiKey: string,
+    dashscopeKey: string,
+) {
+    vi.resetModules();
+    vi.stubEnv("OPENAI_API_KEY", openaiKey);
+    vi.stubEnv("OM_OPENAI_API_KEY", scopedOpenaiKey);
+    vi.stubEnv("DASHSCOPE_API_KEY", dashscopeKey);
+    vi.stubEnv(
+        "OM_OPENAI_BASE_URL",
+        "https://workspace.cn-beijing.maas.aliyuncs.com/compatible-mode/v1",
+    );
+    vi.stubEnv("OM_OPENAI_MODEL", "text-embedding-v4");
+    return await import("../src/core/cfg");
+}
+
+describe("DashScope OpenAI-compatible configuration", () => {
+    afterEach(() => {
+        vi.unstubAllEnvs();
+        vi.resetModules();
+    });
+
+    it("uses DASHSCOPE_API_KEY when OpenAI keys are absent", async () => {
+        const { env } = await loadConfig("", "", "sk-dashscope-test");
+
+        expect(env.openai_key).toBe("sk-dashscope-test");
+        expect(env.openai_base_url).toBe(
+            "https://workspace.cn-beijing.maas.aliyuncs.com/compatible-mode/v1",
+        );
+        expect(env.openai_model).toBe("text-embedding-v4");
+    });
+
+    it("preserves the existing OpenAI key precedence", async () => {
+        const { env } = await loadConfig(
+            "sk-openai-test",
+            "sk-scoped-test",
+            "sk-dashscope-test",
+        );
+
+        expect(env.openai_key).toBe("sk-openai-test");
+    });
+});

--- a/packages/openmemory-py/src/openmemory/core/config.py
+++ b/packages/openmemory-py/src/openmemory/core/config.py
@@ -47,7 +47,11 @@ class EnvConfig:
         self.max_context_tokens = int(get("context", "max_tokens", "OM_MAX_CONTEXT_TOKENS", 2048))
         self.decay_half_life = float(get("decay", "half_life_days", "OM_DECAY_HALF_LIFE", 14))
         self.decay_lambda = num(os.getenv("OM_DECAY_LAMBDA"), 0.02)
-        self.openai_key = get("ai", "openai_key", "OPENAI_API_KEY", "") or os.getenv("OM_OPENAI_API_KEY")
+        self.openai_key = (
+            get("ai", "openai_key", "OPENAI_API_KEY", "")
+            or os.getenv("OM_OPENAI_API_KEY")
+            or os.getenv("DASHSCOPE_API_KEY")
+        )
         self.openai_base_url = get("ai", "openai_base", "OM_OPENAI_BASE_URL", "https://api.openai.com/v1")
         self.openai_model = get("ai", "openai_model", "OM_OPENAI_MODEL", None)
 

--- a/packages/openmemory-py/tests/test_dashscope.py
+++ b/packages/openmemory-py/tests/test_dashscope.py
@@ -1,0 +1,26 @@
+from openmemory.core.config import EnvConfig
+
+
+def test_dashscope_key_is_used_for_openai_compatible_provider(monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OM_OPENAI_API_KEY", raising=False)
+    monkeypatch.setenv("DASHSCOPE_API_KEY", "sk-dashscope-test")
+    monkeypatch.setenv(
+        "OM_OPENAI_BASE_URL",
+        "https://workspace.cn-beijing.maas.aliyuncs.com/compatible-mode/v1",
+    )
+    monkeypatch.setenv("OM_OPENAI_MODEL", "text-embedding-v4")
+
+    config = EnvConfig()
+
+    assert config.openai_key == "sk-dashscope-test"
+    assert config.openai_base_url.endswith("/compatible-mode/v1")
+    assert config.openai_model == "text-embedding-v4"
+
+
+def test_openai_key_keeps_precedence_over_dashscope(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-openai-test")
+    monkeypatch.setenv("OM_OPENAI_API_KEY", "sk-scoped-test")
+    monkeypatch.setenv("DASHSCOPE_API_KEY", "sk-dashscope-test")
+
+    assert EnvConfig().openai_key == "sk-openai-test"


### PR DESCRIPTION
## Summary
- accept the official `DASHSCOPE_API_KEY` in the existing OpenAI-compatible embedding provider
- preserve existing `OPENAI_API_KEY` and `OM_OPENAI_API_KEY` precedence
- pass and mask the key in Docker/dashboard settings, and document Bailian workspace URL plus `text-embedding-v4`
- add JavaScript and Python regression tests

This deliberately reuses the existing OpenAI-compatible provider instead of adding a parallel DashScope provider.

## Verification
- JavaScript: 10 test files, 49 tests passed
- TypeScript: `tsc --noEmit` passed
- Python: fallback/precedence assertions and `py_compile` passed

Official API reference: https://help.aliyun.com/zh/model-studio/embedding-interfaces-compatible-with-openai/