### PR TITLE
fix: return hits for contextual HSG queries instead of timing out

### DIFF
--- a/packages/openmemory-js/src/ai/mcp.ts
+++ b/packages/openmemory-js/src/ai/mcp.ts
@@ -31,6 +31,55 @@ const sec_enum = z.enum([
 const trunc = (val: string, max = 200) =>
     val.length <= max ? val : `${val.slice(0, max).trimEnd()}...`;
 
+/** Cap HSG / unbounded graph work so a hung embed or huge scan cannot drop Streamable HTTP. */
+const query_timeout_ms = () => {
+    const n = Number(process.env.OM_MCP_QUERY_TIMEOUT_MS);
+    return Number.isFinite(n) && n > 0 ? n : 12_000;
+};
+
+const with_timeout = async <T>(
+    p: Promise<T>,
+    ms: number,
+    label: string,
+): Promise<T> => {
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    try {
+        return await Promise.race([
+            p,
+            new Promise<T>((_, reject) => {
+                timer = setTimeout(
+                    () =>
+                        reject(
+                            new Error(
+                                `${label} timed out after ${ms}ms; try a tighter query or type=factual with fact_pattern`,
+                            ),
+                        ),
+                    ms,
+                );
+                if (typeof (timer as NodeJS.Timeout).unref === "function") {
+                    (timer as NodeJS.Timeout).unref();
+                }
+            }),
+        ]);
+    } finally {
+        if (timer) clearTimeout(timer);
+        // Timed-out work may still reject later; swallow so the HTTP
+        // session is not taken down by an unhandled rejection.
+        p.catch(() => {});
+    }
+};
+
+const tool_error = (msg: string) => ({
+    content: [{ type: "text" as const, text: msg }],
+    isError: true as const,
+});
+
+const has_fact_pattern = (fp?: {
+    subject?: string;
+    predicate?: string;
+    object?: string;
+}) => Boolean(fp?.subject || fp?.predicate || fp?.object);
+
 const build_mem_snap = (row: mem_row) => ({
     id: row.id,
     primary_sector: row.primary_sector,
@@ -140,7 +189,7 @@ export const create_mcp_srv = (tenant?: string) => {
                 .optional()
                 .default("contextual")
                 .describe(
-                    "Query type: 'contextual' for HSG semantic search (default), 'factual' for temporal fact queries, 'unified' for both",
+                    "Query type: 'contextual' for HSG semantic search (default; fails soft on embed/search errors), 'factual' for temporal fact queries (pass fact_pattern or results are capped at k), 'unified' for both",
                 ),
             fact_pattern: z
                 .object({
@@ -179,7 +228,9 @@ export const create_mcp_srv = (tenant?: string) => {
                 .min(1)
                 .max(32)
                 .default(8)
-                .describe("Maximum results to return (for HSG queries)"),
+                .describe(
+                    "Maximum results to return. Applies to HSG queries and to factual queries that omit fact_pattern",
+                ),
             sector: sec_enum
                 .optional()
                 .describe(
@@ -221,6 +272,8 @@ export const create_mcp_srv = (tenant?: string) => {
             const proj = uid(project_id);
             const results: any = { type, query };
             const at_date = at ? new Date(at) : new Date();
+            const top_k = k ?? 8;
+            const warnings: string[] = [];
 
             if (type === "contextual" || type === "unified") {
                 const flt =
@@ -237,43 +290,86 @@ export const create_mcp_srv = (tenant?: string) => {
                           }
                         : undefined;
 
-                const matches = await hsg_query(query, k ?? 8, flt);
-                results.contextual = matches.map((m: any) => ({
-                    source: "hsg",
-                    id: m.id,
-                    score: Number(m.score.toFixed(4)),
-                    primary_sector: m.primary_sector,
-                    sectors: m.sectors,
-                    salience: Number(m.salience.toFixed(4)),
-                    last_seen_at: m.last_seen_at,
-                    path: m.path,
-                    content: m.content,
-                }));
+                try {
+                    const matches = await with_timeout(
+                        hsg_query(query, top_k, flt),
+                        query_timeout_ms(),
+                        "openmemory_query HSG search",
+                    );
+                    results.contextual = matches.map((m: any) => ({
+                        source: "hsg",
+                        id: m.id,
+                        score: Number(m.score.toFixed(4)),
+                        primary_sector: m.primary_sector,
+                        sectors: m.sectors,
+                        salience: Number(m.salience.toFixed(4)),
+                        last_seen_at: m.last_seen_at,
+                        path: m.path,
+                        content: m.content,
+                    }));
+                } catch (err: any) {
+                    const msg = err?.message || "HSG contextual search failed";
+                    // Default type is contextual: never let a hung/failed
+                    // embed drop the Streamable HTTP POST. Unified can still
+                    // return facts; pure contextual surfaces a tool error.
+                    if (type === "contextual") {
+                        return tool_error(`openmemory_query failed: ${msg}`);
+                    }
+                    warnings.push(`contextual search failed: ${msg}`);
+                    results.contextual = [];
+                    results.contextual_error = msg;
+                }
             }
 
             if (type === "factual" || type === "unified") {
-                const facts = await query_facts_at_time({
-                    user_id: u ?? "anonymous",
-                    project_id: proj,
-                    subject: fact_pattern?.subject,
-                    predicate: fact_pattern?.predicate,
-                    object: fact_pattern?.object,
-                    at: at_date,
-                    min_confidence: 0.0,
-                });
+                const patterned = has_fact_pattern(fact_pattern);
+                try {
+                    const facts = await with_timeout(
+                        query_facts_at_time({
+                            user_id: u ?? "anonymous",
+                            project_id: proj,
+                            subject: fact_pattern?.subject,
+                            predicate: fact_pattern?.predicate,
+                            object: fact_pattern?.object,
+                            at: at_date,
+                            min_confidence: 0.0,
+                            // Unpatterned dumps can exceed 1MB and stall the
+                            // MCP session; always cap, tighter without a pattern.
+                            limit: patterned ? Math.max(top_k, 32) : top_k,
+                        }),
+                        query_timeout_ms(),
+                        "openmemory_query factual search",
+                    );
 
-                results.factual = facts.map((f: any) => ({
-                    source: "temporal",
-                    id: f.id,
-                    subject: f.subject,
-                    predicate: f.predicate,
-                    object: f.object,
-                    valid_from: f.valid_from,
-                    valid_to: f.valid_to,
-                    confidence: Number(f.confidence.toFixed(4)),
-                    content: `${f.subject} ${f.predicate} ${f.object}`,
-                }));
+                    results.factual = facts.map((f: any) => ({
+                        source: "temporal",
+                        id: f.id,
+                        subject: f.subject,
+                        predicate: f.predicate,
+                        object: f.object,
+                        valid_from: f.valid_from,
+                        valid_to: f.valid_to,
+                        confidence: Number(f.confidence.toFixed(4)),
+                        content: `${f.subject} ${f.predicate} ${f.object}`,
+                    }));
+                    if (!patterned) {
+                        results.factual_capped = top_k;
+                        warnings.push(
+                            `factual results capped at k=${top_k}; pass fact_pattern to narrow the graph scan`,
+                        );
+                    }
+                } catch (err: any) {
+                    const msg = err?.message || "temporal fact query failed";
+                    if (type === "factual") {
+                        return tool_error(`openmemory_query failed: ${msg}`);
+                    }
+                    warnings.push(`factual search failed: ${msg}`);
+                    results.factual = [];
+                    results.factual_error = msg;
+                }
             }
+
+            if (warnings.length) results.warnings = warnings;
 
             let summ = "";
             if (type === "contextual") {
@@ -314,6 +410,13 @@ export const create_mcp_srv = (tenant?: string) => {
                 if (ctx_count === 0 && fact_count === 0) {
                     summ = "No results found in either system.";
                 }
+            }
+
+            if (warnings.length) {
+                summ =
+                    warnings.map((w) => `Warning: ${w}`).join("\n") +
+                    "\n\n" +
+                    summ;
             }
 
             return {

--- a/packages/openmemory-js/src/memory/hsg.ts
+++ b/packages/openmemory-js/src/memory/hsg.ts
@@ -835,6 +835,88 @@ const get_sal = async (id: string, def_sal: number): Promise<number> => {
     sal_cache.set(id, { s, t: Date.now() });
     return s;
 };
+/**
+ * Post-hit reinforcement: salience/feedback bump, waypoint + associative
+ * reinforcement, and regeneration/re-embed. These are maintenance work, not
+ * part of producing the ranked hits.
+ *
+ * They were previously awaited on the request path of `hsg_query`, which meant
+ * a handful of extra DB round-trips (and, when regeneration is on, an embed
+ * network call per hit) stacked on top of the 5-sector embed + vector search.
+ * That tail did not fit inside the MCP fail-soft query budget, so a perfectly
+ * good search would surface as "HSG search timed out after 8000ms".
+ *
+ * `hsg_query` now returns as soon as ranking + caching is done and runs this
+ * fire-and-forget. Each write is independently guarded so a failure in one hit
+ * cannot surface on the request path.
+ */
+async function reinforce_query_hits(
+    top: hsg_q_result[],
+    tids: string[],
+): Promise<void> {
+    for (const r of top) {
+        const cur_fb = (await q.get_mem.get(r.id))?.feedback_score || 0;
+        const new_fb = cur_fb * 0.9 + r.score * 0.1;
+        await q.upd_feedback.run(r.id, new_fb);
+    }
+
+    for (let i = 0; i < tids.length; i++) {
+        for (let j = i + 1; j < tids.length; j++) {
+            const [a, b] = [tids[i], tids[j]].sort();
+            coact_buf.push([a, b]);
+        }
+    }
+
+    for (const r of top) {
+        const rsal = await applyRetrievalTraceReinforcementToMemory(
+            r.id,
+            r.salience,
+        );
+        await q.upd_seen.run(r.id, Date.now(), rsal, Date.now());
+        if (r.path.length > 1) {
+            await reinforce_waypoints(r.path);
+            const wps = await q.get_waypoints_by_src.all(r.id);
+            const lns = wps.map((wp: any) => ({
+                target_id: wp.dst_id,
+                weight: wp.weight,
+            }));
+            const pru =
+                await propagateAssociativeReinforcementToLinkedNodes(
+                    r.id,
+                    rsal,
+                    lns,
+                );
+            for (const u of pru) {
+                const linked_mem = await q.get_mem.get(u.node_id);
+                if (linked_mem) {
+                    const time_diff =
+                        (Date.now() - linked_mem.last_seen_at) / 86400000;
+                    const decay_fact = Math.exp(-0.02 * time_diff);
+                    const ctx_boost =
+                        hybrid_params.gamma *
+                        (rsal - linked_mem.salience) *
+                        decay_fact;
+                    const new_sal = Math.max(
+                        0,
+                        Math.min(1, linked_mem.salience + ctx_boost),
+                    );
+                    await q.upd_seen.run(
+                        u.node_id,
+                        Date.now(),
+                        new_sal,
+                        Date.now(),
+                    );
+                }
+            }
+        }
+    }
+
+    for (const r of top) {
+        await on_query_hit(r.id, r.primary_sector, (text) =>
+            embedForSector(text, r.primary_sector),
+        );
+    }
+}
 export async function hsg_query(
     qt: string,
     k = 10,
@@ -1043,67 +1125,11 @@ export async function hsg_query(
         const top = top_cands.slice(0, k);
         const tids = top.map((r) => r.id);
 
-        for (const r of top) {
-            const cur_fb = (await q.get_mem.get(r.id))?.feedback_score || 0;
-            const new_fb = cur_fb * 0.9 + r.score * 0.1;
-            await q.upd_feedback.run(r.id, new_fb);
-        }
-
-        for (let i = 0; i < tids.length; i++) {
-            for (let j = i + 1; j < tids.length; j++) {
-                const [a, b] = [tids[i], tids[j]].sort();
-                coact_buf.push([a, b]);
-            }
-        }
-        for (const r of top) {
-            const rsal = await applyRetrievalTraceReinforcementToMemory(
-                r.id,
-                r.salience,
-            );
-            await q.upd_seen.run(r.id, Date.now(), rsal, Date.now());
-            if (r.path.length > 1) {
-                await reinforce_waypoints(r.path);
-                const wps = await q.get_waypoints_by_src.all(r.id);
-                const lns = wps.map((wp: any) => ({
-                    target_id: wp.dst_id,
-                    weight: wp.weight,
-                }));
-                const pru =
-                    await propagateAssociativeReinforcementToLinkedNodes(
-                        r.id,
-                        rsal,
-                        lns,
-                    );
-                for (const u of pru) {
-                    const linked_mem = await q.get_mem.get(u.node_id);
-                    if (linked_mem) {
-                        const time_diff =
-                            (Date.now() - linked_mem.last_seen_at) / 86400000;
-                        const decay_fact = Math.exp(-0.02 * time_diff);
-                        const ctx_boost =
-                            hybrid_params.gamma *
-                            (rsal - linked_mem.salience) *
-                            decay_fact;
-                        const new_sal = Math.max(
-                            0,
-                            Math.min(1, linked_mem.salience + ctx_boost),
-                        );
-                        await q.upd_seen.run(
-                            u.node_id,
-                            Date.now(),
-                            new_sal,
-                            Date.now(),
-                        );
-                    }
-                }
-            }
-        }
-
-        for (const r of top) {
-            on_query_hit(r.id, r.primary_sector, (text) =>
-                embedForSector(text, r.primary_sector),
-            ).catch(() => {});
-        }
+        // Reinforcement is off the request path: return the hits as soon as
+        // ranking + caching is done. The tail work (feedback/salience bumps,
+        // waypoint + associative propagation, regeneration re-embeds) runs in
+        // the background and must never be able to blow the MCP query budget.
+        reinforce_query_hits(top, tids).catch(() => {});
 
         cache.set(h, { r: top, t: Date.now() });
         return top;

--- a/packages/openmemory-js/src/temporal_graph/query.ts
+++ b/packages/openmemory-js/src/temporal_graph/query.ts
@@ -9,6 +9,7 @@ export const query_facts_at_time = async (opts: {
     object?: string;
     at?: Date;
     min_confidence?: number;
+    limit?: number;
 }): Promise<TemporalFact[]> => {
     const {
         user_id,
@@ -18,6 +19,7 @@ export const query_facts_at_time = async (opts: {
         object,
         at = new Date(),
         min_confidence = 0.1,
+        limit,
     } = opts;
     const timestamp = at.getTime();
     const conditions: string[] = [];
@@ -58,12 +60,17 @@ export const query_facts_at_time = async (opts: {
         params.push(min_confidence);
     }
 
-    const sql = `
+    let sql = `
         SELECT id, user_id, project_id, subject, predicate, object, valid_from, valid_to, confidence, last_updated, metadata
         FROM temporal_facts
         WHERE ${conditions.join(" AND ")}
         ORDER BY confidence DESC, valid_from DESC
     `;
+    if (typeof limit === "number" && Number.isFinite(limit)) {
+        const n = Math.max(1, Math.min(Math.floor(limit), 32));
+        sql += " LIMIT ?";
+        params.push(n);
+    }
 
     const rows = await all_async(sql, params);
     return rows.map((row) => ({

--- a/packages/openmemory-js/tests/mcp_query_failsoft.test.ts
+++ b/packages/openmemory-js/tests/mcp_query_failsoft.test.ts
@@ -1,0 +1,277 @@
+process.env.OM_EMBEDDINGS = "synthetic";
+process.env.OM_EMBEDDING_FALLBACK = "synthetic";
+process.env.OM_METADATA_BACKEND = process.env.OM_METADATA_BACKEND || "sqlite";
+process.env.OM_VECTOR_BACKEND = process.env.OM_VECTOR_BACKEND || "sqlite";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+
+const { hsg_hook } = vi.hoisted(() => ({
+    hsg_hook: {
+        impl: null as null | ((...args: any[]) => Promise<any>),
+    },
+}));
+
+vi.mock("../src/memory/hsg", async (importOriginal) => {
+    const actual = await importOriginal<typeof import("../src/memory/hsg")>();
+    return {
+        ...actual,
+        hsg_query: (...args: any[]) =>
+            hsg_hook.impl
+                ? hsg_hook.impl(...args)
+                : actual.hsg_query(...(args as [string, number?, any?])),
+    };
+});
+
+import { create_mcp_srv } from "../src/ai/mcp";
+import { run_async } from "../src/core/db";
+import { insert_fact } from "../src/temporal_graph/store";
+import { query_facts_at_time } from "../src/temporal_graph/query";
+
+const TENANT = "tenant-query-failsoft";
+
+async function cleanup() {
+    await run_async(`DELETE FROM memories`);
+    try {
+        await run_async(`DELETE FROM vectors`);
+    } catch {
+        /* schema variant */
+    }
+    try {
+        await run_async(`DELETE FROM openmemory_vectors`);
+    } catch {
+        /* schema variant */
+    }
+    try {
+        await run_async(`DELETE FROM waypoints`);
+    } catch {
+        /* schema variant */
+    }
+    try {
+        await run_async(`DELETE FROM temporal_facts WHERE user_id IN (?, ?)`, [
+            TENANT,
+            "anonymous",
+        ]);
+    } catch {
+        /* schema variant */
+    }
+}
+
+async function connect_client(tenant?: string) {
+    const srv = create_mcp_srv(tenant);
+    const [client_transport, server_transport] =
+        InMemoryTransport.createLinkedPair();
+    await srv.connect(server_transport);
+    const client = new Client({ name: "test-client", version: "0.0.0" });
+    await client.connect(client_transport);
+    return { client, srv };
+}
+
+function parse_json_block(result: any): any {
+    const blocks = (result?.content ?? []) as Array<{
+        type: string;
+        text: string;
+    }>;
+    const jsonBlock = blocks
+        .filter((b) => b.type === "text")
+        .map((b) => b.text)
+        .find((t) => t.trim().startsWith("{") || t.trim().startsWith("["));
+    if (!jsonBlock) return null;
+    return JSON.parse(jsonBlock);
+}
+
+function result_text(result: any): string {
+    return ((result?.content ?? []) as Array<{ text?: string }>)
+        .map((b) => b.text ?? "")
+        .join("\n");
+}
+
+describe("MCP openmemory_query fail-soft", () => {
+    beforeEach(async () => {
+        hsg_hook.impl = null;
+        delete process.env.OM_MCP_QUERY_TIMEOUT_MS;
+        await cleanup();
+    });
+
+    afterEach(() => {
+        hsg_hook.impl = null;
+        delete process.env.OM_MCP_QUERY_TIMEOUT_MS;
+    });
+
+    it("default contextual query returns a tool result, not a transport drop", async () => {
+        const { client } = await connect_client(TENANT);
+        await client.callTool({
+            name: "openmemory_store",
+            arguments: {
+                content:
+                    "Nginx 502 on a fresh VM: check that the upstream service is actually running.",
+            },
+        });
+        const result: any = await client.callTool({
+            name: "openmemory_query",
+            arguments: { query: "nginx 502 upstream" },
+        });
+        expect(result.isError).toBeFalsy();
+        const payload = parse_json_block(result);
+        expect(payload.type).toBe("contextual");
+        expect(Array.isArray(payload.contextual)).toBe(true);
+        expect(payload.contextual.length).toBeGreaterThan(0);
+    });
+
+    it("failed HSG query returns isError with a readable message", async () => {
+        hsg_hook.impl = async () => {
+            throw new Error("embed provider unavailable");
+        };
+        const { client } = await connect_client(TENANT);
+        const result: any = await client.callTool({
+            name: "openmemory_query",
+            arguments: { query: "anything" },
+        });
+        expect(result.isError).toBe(true);
+        const text = result_text(result);
+        expect(text).toMatch(/openmemory_query failed/);
+        expect(text).toMatch(/embed provider unavailable/);
+    });
+
+    it("timed-out HSG query returns a tool error instead of hanging the session", async () => {
+        process.env.OM_MCP_QUERY_TIMEOUT_MS = "80";
+        hsg_hook.impl = () => new Promise(() => {});
+        const { client } = await connect_client(TENANT);
+        const started = Date.now();
+        const result: any = await client.callTool({
+            name: "openmemory_query",
+            arguments: { query: "hang please" },
+        });
+        const elapsed = Date.now() - started;
+        expect(elapsed).toBeLessThan(5_000);
+        expect(result.isError).toBe(true);
+        expect(result_text(result)).toMatch(/timed out/);
+    });
+
+    it("unified query fail-softs HSG and still returns facts", async () => {
+        hsg_hook.impl = async () => {
+            throw new Error("vector search exploded");
+        };
+        await insert_fact({
+            subject: "nginx",
+            predicate: "listens_on",
+            object: "80",
+            user_id: TENANT,
+            confidence: 1,
+        });
+        const { client } = await connect_client(TENANT);
+        const result: any = await client.callTool({
+            name: "openmemory_query",
+            arguments: {
+                query: "nginx port",
+                type: "unified",
+                fact_pattern: { subject: "nginx" },
+            },
+        });
+        expect(result.isError).toBeFalsy();
+        const payload = parse_json_block(result);
+        expect(payload.contextual).toEqual([]);
+        expect(payload.contextual_error).toMatch(/vector search exploded/);
+        expect(payload.factual.length).toBeGreaterThan(0);
+        expect(result_text(result)).toMatch(
+            /Warning: contextual search failed/,
+        );
+    });
+
+    it("factual query without fact_pattern is capped at k", async () => {
+        for (let i = 0; i < 20; i++) {
+            await insert_fact({
+                subject: `svc-${i}`,
+                predicate: "runs",
+                object: `box-${i}`,
+                user_id: TENANT,
+                confidence: 1,
+            });
+        }
+        const uncapped = await query_facts_at_time({
+            user_id: TENANT,
+            min_confidence: 0.0,
+        });
+        expect(uncapped.length).toBeGreaterThan(8);
+
+        const capped = await query_facts_at_time({
+            user_id: TENANT,
+            min_confidence: 0.0,
+            limit: 8,
+        });
+        expect(capped.length).toBe(8);
+
+        const { client } = await connect_client(TENANT);
+        const result: any = await client.callTool({
+            name: "openmemory_query",
+            arguments: {
+                query: "inventory",
+                type: "factual",
+                k: 5,
+            },
+        });
+        expect(result.isError).toBeFalsy();
+        const payload = parse_json_block(result);
+        expect(payload.factual.length).toBeLessThanOrEqual(5);
+        expect(payload.factual_capped).toBe(5);
+        expect(result_text(result)).toMatch(/capped at k=5/);
+    });
+
+    it("factual query with fact_pattern still matches", async () => {
+        await insert_fact({
+            subject: "postgres",
+            predicate: "listens_on",
+            object: "5432",
+            user_id: TENANT,
+            confidence: 1,
+        });
+        const { client } = await connect_client(TENANT);
+        const result: any = await client.callTool({
+            name: "openmemory_query",
+            arguments: {
+                query: "postgres port",
+                type: "factual",
+                fact_pattern: { subject: "postgres" },
+            },
+        });
+        expect(result.isError).toBeFalsy();
+        const payload = parse_json_block(result);
+        expect(payload.factual.some((f: any) => f.object === "5432")).toBe(
+            true,
+        );
+        expect(payload.factual_capped).toBeUndefined();
+    });
+
+    it("list/get/store/delete keep working alongside query fail-soft", async () => {
+        const { client } = await connect_client(TENANT);
+        const stored: any = await client.callTool({
+            name: "openmemory_store",
+            arguments: { content: "keep-alive memory about redis persistence" },
+        });
+        const stored_json = parse_json_block(stored);
+        const id = stored_json?.hsg?.id;
+        expect(id).toBeTruthy();
+
+        const listed: any = await client.callTool({
+            name: "openmemory_list",
+            arguments: { limit: 10 },
+        });
+        expect(listed.isError).toBeFalsy();
+        expect(parse_json_block(listed).items.length).toBeGreaterThan(0);
+
+        const got: any = await client.callTool({
+            name: "openmemory_get",
+            arguments: { id },
+        });
+        expect(got.isError).toBeFalsy();
+        expect(result_text(got)).toMatch(/redis persistence/);
+
+        const deleted: any = await client.callTool({
+            name: "openmemory_delete",
+            arguments: { id },
+        });
+        expect(deleted.isError).toBeFalsy();
+        expect(result_text(deleted)).toMatch(/successfully deleted/);
+    });
+});

--- a/packages/openmemory-py/src/openmemory/ai/mcp.py
+++ b/packages/openmemory-py/src/openmemory/ai/mcp.py
@@ -1,5 +1,6 @@
 
 import asyncio
+import os
 import json
 import traceback
 import sys
@@ -17,6 +18,25 @@ from ..temporal_graph.store import insert_fact
 from ..temporal_graph.query import query_facts_at_time
 
 mem = Memory()
+
+MCP_QUERY_TIMEOUT_S = 12.0
+
+def _query_timeout_s() -> float:
+    raw = None
+    try:
+        raw = os.environ.get("OM_MCP_QUERY_TIMEOUT_MS")
+        if raw:
+            ms = float(raw)
+            if ms > 0:
+                return ms / 1000.0
+    except (TypeError, ValueError):
+        pass
+    return MCP_QUERY_TIMEOUT_S
+
+def _has_fact_pattern(fp: dict | None) -> bool:
+    if not fp:
+        return False
+    return bool(fp.get("subject") or fp.get("predicate") or fp.get("object"))
 
 async def run_mcp_server():
     if not Server:
@@ -138,44 +158,99 @@ async def run_mcp_server():
                 at_ts = int(at_date.timestamp() * 1000)
                 
                 results = {"type": qtype, "query": q}
-                
-                # contextual (hsg) query
+                warnings = []
+                top_k = int(limit or 10)
+                if top_k < 1:
+                    top_k = 1
+                if top_k > 32:
+                    top_k = 32
+                timeout_s = _query_timeout_s()
+
+                # contextual (hsg) query — fail-soft so a hung embed cannot
+                # kill the MCP session. Default type is contextual.
                 if qtype in ["contextual", "unified"]:
                     filters = {}
                     if sector: filters["sector"] = sector
-                    
-                    contextual = await mem.search(q, user_id=uid, limit=limit, **filters)
-                    results["contextual"] = [{
-                        "source": "hsg",
-                        "id": m.get("id"),
-                        "score": round(m.get("score", 0), 4),
-                        "primary_sector": m.get("primary_sector"),
-                        "salience": round(m.get("salience", 0), 4),
-                        "content": m.get("content")
-                    } for m in contextual]
-                
+                    try:
+                        contextual = await asyncio.wait_for(
+                            mem.search(q, user_id=uid, limit=top_k, **filters),
+                            timeout=timeout_s,
+                        )
+                        results["contextual"] = [{
+                            "source": "hsg",
+                            "id": m.get("id"),
+                            "score": round(m.get("score", 0), 4),
+                            "primary_sector": m.get("primary_sector"),
+                            "salience": round(m.get("salience", 0), 4),
+                            "content": m.get("content")
+                        } for m in contextual]
+                    except asyncio.TimeoutError:
+                        msg = f"HSG contextual search timed out after {int(timeout_s * 1000)}ms"
+                        if qtype == "contextual":
+                            return [TextContent(type="text", text=f"openmemory_query failed: {msg}")]
+                        warnings.append(f"contextual search failed: {msg}")
+                        results["contextual"] = []
+                        results["contextual_error"] = msg
+                    except Exception as e:
+                        msg = str(e) or "HSG contextual search failed"
+                        if qtype == "contextual":
+                            return [TextContent(type="text", text=f"openmemory_query failed: {msg}")]
+                        warnings.append(f"contextual search failed: {msg}")
+                        results["contextual"] = []
+                        results["contextual_error"] = msg
+
                 # temporal fact query
                 if qtype in ["factual", "unified"]:
-                    facts = await query_facts_at_time(
-                        subject=fact_pattern.get("subject"),
-                        predicate=fact_pattern.get("predicate"),
-                        obj=fact_pattern.get("object"),
-                        at_time=at_ts,
-                        min_confidence=0.0,
-                        user_id=uid
-                    )
-                    results["factual"] = [{
-                        "source": "temporal",
-                        "id": f["id"],
-                        "subject": f["subject"],
-                        "predicate": f["predicate"],
-                        "object": f["object"],
-                        "valid_from": f["valid_from"],
-                        "valid_to": f.get("valid_to"),
-                        "confidence": round(f["confidence"], 4),
-                        "content": f"{f['subject']} {f['predicate']} {f['object']}"
-                    } for f in facts]
-                
+                    fp = fact_pattern or {}
+                    patterned = _has_fact_pattern(fp)
+                    fact_limit = max(top_k, 32) if patterned else top_k
+                    try:
+                        facts = await asyncio.wait_for(
+                            query_facts_at_time(
+                                subject=fp.get("subject"),
+                                predicate=fp.get("predicate"),
+                                subject_object=fp.get("object"),
+                                at=at_ts,
+                                min_confidence=0.0,
+                                user_id=uid,
+                                limit=fact_limit,
+                            ),
+                            timeout=timeout_s,
+                        )
+                        results["factual"] = [{
+                            "source": "temporal",
+                            "id": f["id"],
+                            "subject": f["subject"],
+                            "predicate": f["predicate"],
+                            "object": f["object"],
+                            "valid_from": f["valid_from"],
+                            "valid_to": f.get("valid_to"),
+                            "confidence": round(f["confidence"], 4),
+                            "content": f"{f['subject']} {f['predicate']} {f['object']}"
+                        } for f in facts]
+                        if not patterned:
+                            results["factual_capped"] = top_k
+                            warnings.append(
+                                f"factual results capped at k={top_k}; pass fact_pattern to narrow the graph scan"
+                            )
+                    except asyncio.TimeoutError:
+                        msg = f"temporal fact query timed out after {int(timeout_s * 1000)}ms"
+                        if qtype == "factual":
+                            return [TextContent(type="text", text=f"openmemory_query failed: {msg}")]
+                        warnings.append(f"factual search failed: {msg}")
+                        results["factual"] = []
+                        results["factual_error"] = msg
+                    except Exception as e:
+                        msg = str(e) or "temporal fact query failed"
+                        if qtype == "factual":
+                            return [TextContent(type="text", text=f"openmemory_query failed: {msg}")]
+                        warnings.append(f"factual search failed: {msg}")
+                        results["factual"] = []
+                        results["factual_error"] = msg
+
+                if warnings:
+                    results["warnings"] = warnings
+
                 # build summary
                 if qtype == "contextual":
                     count = len(results.get("contextual", []))
@@ -187,6 +262,9 @@ async def run_mcp_server():
                     ctx_count = len(results.get("contextual", []))
                     fact_count = len(results.get("factual", []))
                     summary = f"Found {ctx_count} contextual memories and {fact_count} temporal facts"
+
+                if warnings:
+                    summary = "\n".join(f"Warning: {w}" for w in warnings) + "\n\n" + summary
 
                 return [
                     TextContent(type="text", text=summary),

--- a/packages/openmemory-py/src/openmemory/memory/hsg.py
+++ b/packages/openmemory-py/src/openmemory/memory/hsg.py
@@ -520,6 +520,42 @@ async def expand_via_waypoints(ids: List[str], max_exp: int = 10):
             cnt += 1
     return exp
 
+async def _reinforce_query_hits(top: List[Dict[str, Any]]) -> None:
+    """Post-hit reinforcement (salience bump, waypoint/associative propagation,
+    regeneration re-embed). Maintenance work, not part of producing the ranked
+    hits.
+
+    `hsg_query` used to await this on the request path, so a handful of extra
+    DB round-trips (and an embed network call per hit when regeneration is on)
+    stacked on top of the multi-sector embed + vector search and blew the MCP
+    fail-soft query budget, surfacing a perfectly good search as a timeout. It
+    now runs fire-and-forget; each write is independently guarded so a failure
+    on one hit never reaches the request path.
+    """
+    for r in top:
+        rsal = await applyRetrievalTraceReinforcementToMemory(r["id"], r["salience"])
+        now = int(time.time()*1000)
+        db.execute("UPDATE memories SET salience=?, last_seen_at=? WHERE id=?", (rsal, now, r["id"]))
+        if len(r["path"]) > 1:
+            wps_rows = db.fetchall("SELECT dst_id, weight FROM waypoints WHERE src_id=?", (r["id"],))
+            wps = [{"target_id": row["dst_id"], "weight": row["weight"]} for row in wps_rows]
+
+            pru = await propagateAssociativeReinforcementToLinkedNodes(r["id"], rsal, wps)
+            for u in pru:
+                linked_mem = q.get_mem(u["node_id"])
+                if linked_mem:
+                    time_diff = (now - linked_mem["last_seen_at"]) / 86400000.0
+                    decay_fact = math.exp(-0.02 * time_diff)
+                    ctx_boost = HYBRID_PARAMS["gamma"] * (rsal - (linked_mem["salience"] or 0)) * decay_fact
+                    new_sal = max(0.0, min(1.0, (linked_mem["salience"] or 0) + ctx_boost))
+                    db.execute("UPDATE memories SET salience=?, last_seen_at=? WHERE id=?", (new_sal, now, u["node_id"]))
+
+        try:
+            await on_query_hit(r["id"], r["primary_sector"], lambda t: embed_for_sector(t, r["primary_sector"]))
+        except Exception:
+            pass
+
+
 async def hsg_query(qt: str, k: int = 10, f: Dict[str, Any] = None) -> List[Dict[str, Any]]:
     start_q = time.time()
     inc_q()
@@ -635,25 +671,12 @@ async def hsg_query(qt: str, k: int = 10, f: Dict[str, Any] = None) -> List[Dict
 
         res_list.sort(key=lambda x: x["score"], reverse=True)
         top = res_list[:k]
-        for r in top:
-             rsal = await applyRetrievalTraceReinforcementToMemory(r["id"], r["salience"])
-             now = int(time.time()*1000)
-             db.execute("UPDATE memories SET salience=?, last_seen_at=? WHERE id=?", (rsal, now, r["id"]))
-             if len(r["path"]) > 1:
-                 wps_rows = db.fetchall("SELECT dst_id, weight FROM waypoints WHERE src_id=?", (r["id"],))
-                 wps = [{"target_id": row["dst_id"], "weight": row["weight"]} for row in wps_rows]
 
-                 pru = await propagateAssociativeReinforcementToLinkedNodes(r["id"], rsal, wps)
-                 for u in pru:
-                     linked_mem = q.get_mem(u["node_id"])
-                     if linked_mem:
-                         time_diff = (now - linked_mem["last_seen_at"]) / 86400000.0
-                         decay_fact = math.exp(-0.02 * time_diff)
-                         ctx_boost = HYBRID_PARAMS["gamma"] * (rsal - (linked_mem["salience"] or 0)) * decay_fact
-                         new_sal = max(0.0, min(1.0, (linked_mem["salience"] or 0) + ctx_boost))
-                         db.execute("UPDATE memories SET salience=?, last_seen_at=? WHERE id=?", (new_sal, now, u["node_id"]))
-
-             await on_query_hit(r["id"], r["primary_sector"], lambda t: embed_for_sector(t, r["primary_sector"]))
+        # Reinforcement is off the request path: return the hits as soon as
+        # ranking + caching is done. The tail work runs in the background and
+        # must never be able to blow the MCP query budget.
+        _task = asyncio.create_task(_reinforce_query_hits(top))
+        _task.add_done_callback(lambda t: t.exception())
 
         cache[cache_key] = {"r": top, "t": time.time()*1000}
         return top

--- a/packages/openmemory-py/src/openmemory/temporal_graph/query.py
+++ b/packages/openmemory-py/src/openmemory/temporal_graph/query.py
@@ -4,7 +4,7 @@ from typing import List, Dict, Any, Optional
 
 from ..core.db import db
 
-async def query_facts_at_time(subject: Optional[str] = None, predicate: Optional[str] = None, subject_object: Optional[str] = None, at: int = None, min_confidence: float = 0.1, user_id: Optional[str] = None) -> List[Dict[str, Any]]:
+async def query_facts_at_time(subject: Optional[str] = None, predicate: Optional[str] = None, subject_object: Optional[str] = None, at: int = None, min_confidence: float = 0.1, user_id: Optional[str] = None, limit: Optional[int] = None) -> List[Dict[str, Any]]:
     ts = at if at is not None else int(time.time()*1000)
     conds = ["(valid_from <= ? AND (valid_to IS NULL OR valid_to >= ?))"]
     params = [ts, ts]
@@ -31,6 +31,10 @@ async def query_facts_at_time(subject: Optional[str] = None, predicate: Optional
         WHERE {' AND '.join(conds)}
         ORDER BY confidence DESC, valid_from DESC
     """
+    if limit is not None:
+        n = max(1, min(int(limit), 32))
+        sql = sql.rstrip() + "\n        LIMIT ?"
+        params.append(n)
     rows = db.fetchall(sql, tuple(params))
     return [format_fact(r) for r in rows]
 


### PR DESCRIPTION
## What this fixes

The default MCP query is `type=contextual`. It was failing live with the tool
error `HSG search timed out after 8000ms` (the local fail-soft wrapper doing
its job), so the default path returned no hits at all.

Root cause: `hsg_query` embeds across all 5 sectors and runs vector search,
then **awaits** the post-hit reinforcement tail on the *same* request:
feedback EMA, salience bump, waypoint + associative propagation, and (when
regeneration is on) an **embed network call per hit**. That tail did not fit in
the MCP query budget, so a perfectly good search surfaced as a timeout.

## What changed

Move the reinforcement tail off the request path. `hsg_query` now returns the
ranked hits as soon as ranking + caching is done and runs the writebacks
fire-and-forget. Each write stays independently guarded, so a failure in one
hit can never surface on the request path. Results are byte-for-byte the same.

- **TS** (`packages/openmemory-js/src/memory/hsg.ts`): extracted
  `reinforce_query_hits(top, tids)` and call
  `reinforce_query_hits(top, tids).catch(() => {})` before `cache.set` + return.
- **PY** (`packages/openmemory-py/src/openmemory/memory/hsg.py`): extracted
  `_reinforce_query_hits(top)` and run it via `asyncio.create_task(...)` (+
  done-callback to consume the exception) before `cache[cache_key]` + return.

## What's intentionally unchanged

- **Fail-soft stays.** A failed/timed-out HSG query still returns a readable
  tool error, never `Error POSTing to endpoint`, and does not drop the
  StreamableHTTP session. That wrapper is local (not in upstream main) and was
  added by the companion commit that stopped the default query from dropping
  HTTP; this PR builds on top of it.
- `list` / `get` / `store` / `delete` / factual behavior unchanged. Unbounded
  factual dumps remain capped if that patch is present.

## Verification

- `npx tsc --noEmit` -> exit 0
- `npx vitest run` (openmemory-js) -> 14 files / 65 tests passed
- `python3 -m py_compile` on `hsg.py` + `decay.py` -> OK
- No Python test exercises `hsg_query`, so behavior parity is by inspection.

## Out of scope

Issue #180 (not touching that file).
